### PR TITLE
feat: tts api에 사용자 인증 로직 추가 및 리액트 쿼리 에러 자동 재요청 안되게끔 수정

### DIFF
--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -27,7 +27,7 @@ export default function InterviewClient() {
   const running = phase === 'recording';
 
   // 질문 TTS 조회 (훅 사용)
-  const { data /*, isLoading, isError */ } = useGetTtsQuestions(reportId);
+  const { data, isError, error } = useGetTtsQuestions(reportId);
   const items = (data as any)?.data as QuestionTTSResponse[] | undefined;
   const current = items?.[currentOrder - 1];
   const currentQuestionText = current?.question ?? '질문을 불러오는 중입니다...';
@@ -113,27 +113,39 @@ export default function InterviewClient() {
 
   return (
     <div className="h-screen overflow-hidden flex flex-col">
-      <TopSection running={running} duration={60} onComplete={goNext} />
-      <main className="flex-1 flex overflow-hidden">
-        {/* Left: 아바타 면접관 영역 */}
-        <section className="flex-1 min-w-0 h-full bg-[#F1F5F9] flex flex-col items-center justify-between p-[52px]">
-          <AiAvatar />
-          <audio ref={audioRef} className="hidden" />
-          <Question text={currentQuestionText} />
-        </section>
-        {/* Right: 사용자 영역 */}
-        <section className="flex-1 min-w-0 h-full bg-[#FAFBFC] flex flex-col items-center justify-between p-[52px] gap-[24px]">
-          <UserCamera />
-          <UserAudio active={running} onFinish={handleFinishRecording} />
-        </section>
-      </main>
-      <BottomSection
-        currentQuestion={currentOrder}
-        totalQuestions={10}
-        onNext={goNext}
-        isDisabled={isNextBtnDisabled || isUploading}
-        nextLabel={currentOrder >= 10 ? '종료하기' : '다음 질문'}
-      />
+      {isError ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="px-4 py-3 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm">
+            {(error as any)?.response?.data?.message ||
+              (error as any)?.response?.data?.error ||
+              '질문을 불러오지 못했습니다.'}
+          </div>
+        </div>
+      ) : (
+        <>
+          <TopSection running={running} duration={60} onComplete={goNext} />
+          <main className="flex-1 flex overflow-hidden">
+            {/* Left: 아바타 면접관 영역 */}
+            <section className="flex-1 min-w-0 h-full bg-[#F1F5F9] flex flex-col items-center justify-between p-[52px]">
+              <AiAvatar />
+              <audio ref={audioRef} className="hidden" />
+              <Question text={currentQuestionText} />
+            </section>
+            {/* Right: 사용자 영역 */}
+            <section className="flex-1 min-w-0 h-full bg-[#FAFBFC] flex flex-col items-center justify-between p-[52px] gap-[24px]">
+              <UserCamera />
+              <UserAudio active={running} onFinish={handleFinishRecording} />
+            </section>
+          </main>
+          <BottomSection
+            currentQuestion={currentOrder}
+            totalQuestions={10}
+            onNext={goNext}
+            isDisabled={isNextBtnDisabled || isUploading}
+            nextLabel={currentOrder >= 10 ? '종료하기' : '다음 질문'}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/hooks/useGetTtsQuestions.tsx
+++ b/hooks/useGetTtsQuestions.tsx
@@ -16,7 +16,12 @@ export const useGetTtsQuestions = (reportId: number) => {
   return useQuery<QuestionTTSResponse, Error>({
     queryKey: ['tts-questions', reportId],
     queryFn: () => getTtsQuestions(reportId),
-    staleTime: Infinity, //인터뷰 중 리패치 방지
-    gcTime: 15 * 60 * 1000, //15분동안 캐시 유지
+    staleTime: Infinity,
+    gcTime: 15 * 60 * 1000,
+    retry: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    enabled: Number.isFinite(reportId) && reportId > 0,
   });
 };


### PR DESCRIPTION
## 🔥 PR 제목  
> feat: tts api에 사용자 인증 로직 추가 및 리액트 쿼리 에러 자동 재요청 안되게끔 수정


## ✨ 작업 내용
- tts api에 사용자 인증 로직을 추가하였습니다.


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.



## 📸 스크린샷 / 시연 (선택)  
> 
**리포트 아이디가 유효하지 않은 경우**
<img width="649" height="537" alt="스크린샷 2025-08-19 오후 5 35 45" src="https://github.com/user-attachments/assets/762e62ab-0499-49cc-abdb-aed5030aa3aa" />

**사용자의 리포트 아이디가 아닌 경우**
<img width="645" height="529" alt="스크린샷 2025-08-19 오후 5 34 41" src="https://github.com/user-attachments/assets/c96012ff-1818-41e3-aced-27de4f79c729" />


## 🙏 리뷰어에게 한마디  
> 화이팅!!