### PR TITLE
feat: Report 페이지 및 컴포넌트 구현

### DIFF
--- a/app/(anon)/components/modal/LogoutModal.tsx
+++ b/app/(anon)/components/modal/LogoutModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
+import { signOut } from 'next-auth/react';
 import ModalOverlay from './ModalOverlay';
 import Modal from './Modal';
 import { useModalStore } from '@/stores/useModalStore';
@@ -13,7 +14,8 @@ export default function LogoutModal() {
       <button className="self-stretch h-11 bg-[#3B82F6] rounded-lg inline-flex justify-center items-center">
         <div
           className="text-white text-sm font-semibold cursor-pointer"
-          onClick={() => {
+          onClick={async () => {
+            await signOut({ redirect: false });
             closeModal();
             router.push('/login');
           }}

--- a/app/(anon)/reports/[id]/components/AudioPlayer.tsx
+++ b/app/(anon)/reports/[id]/components/AudioPlayer.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Play from '@/public/assets/icons/play.svg';
+import Square from '@/public/assets/icons/square.svg';
+import ProgressBar from '@/app/(anon)/reports/[id]/components/ProgressBar';
+
+interface AudioPlayerProps {
+  questionNumber: string;
+  questionText: string;
+  audioUrl: string;
+  className?: string;
+}
+
+export default function AudioPlayer({
+  questionNumber,
+  questionText,
+  audioUrl,
+  className = '',
+}: AudioPlayerProps) {
+  // 오디오 재생 상태 관리
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0); //오디오 재생 시간
+  const [isLoading, setIsLoading] = useState(false);
+
+  const audioRef = useRef<HTMLAudioElement>(null); //HTML <audio> 요소 제어
+  const rafIdRef = useRef<number | null>(null); //requestAnimationFrame ID 참조  -> 부드러운 프로그래스바 업데이트 제어
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const handleLoadedMetadata = () => {
+      // 오디오 메타데이터 로드 완료 시 duration 설정
+      setDuration(audio.duration);
+      setIsLoading(false);
+    };
+
+    const handleLoadedData = () => {
+      // 오디오 데이터 로드 완료 시 duration 설정
+      if (audio.duration && !isNaN(audio.duration)) {
+        setDuration(audio.duration);
+      }
+    };
+
+    const handleCanPlay = () => {
+      // 오디오 재생 가능 시 duration 설정
+      if (audio.duration && !isNaN(audio.duration)) {
+        setDuration(audio.duration);
+      }
+    };
+
+    const handleTimeUpdate = () => {
+      // duration이 아직 설정되지 않았다면 다시 시도
+      if (audio.duration && !isNaN(audio.duration)) {
+        setDuration(audio.duration);
+      }
+    };
+
+    const handleEnded = () => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+    };
+
+    const handleError = () => {
+      setIsLoading(false);
+    };
+
+    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
+    audio.addEventListener('loadeddata', handleLoadedData);
+    audio.addEventListener('canplay', handleCanPlay);
+    audio.addEventListener('timeupdate', handleTimeUpdate);
+    audio.addEventListener('ended', handleEnded);
+    audio.addEventListener('error', handleError);
+
+    return () => {
+      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      audio.removeEventListener('loadeddata', handleLoadedData);
+      audio.removeEventListener('canplay', handleCanPlay);
+      audio.removeEventListener('timeupdate', handleTimeUpdate);
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('error', handleError);
+
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, []);
+
+  // 재생/일시정지 토글 함수
+  const togglePlayPause = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+      stopSmoothUpdate();
+    } else {
+      if (audio.readyState === 0) {
+        setIsLoading(true);
+      }
+      audio.play();
+      setIsPlaying(true);
+      startSmoothUpdate();
+    }
+  };
+
+  // 프로그래스바 클릭 시 재생 위치 변경
+  const handleProgressBarClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const progressBar = event.currentTarget;
+    const rect = progressBar.getBoundingClientRect();
+    const clickX = event.clientX - rect.left;
+    const progressBarWidth = rect.width;
+    const clickPosition = clickX / progressBarWidth;
+
+    audio.currentTime = clickPosition * duration;
+  };
+
+  // 시간을 MM:SS 형식으로 포맷팅
+  const formatTime = (time: number): string => {
+    if (isNaN(time)) return '00:00';
+    const minutes = Math.floor(time / 60);
+    const seconds = Math.floor(time % 60);
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  // 프로그래스바 진행률 계산 (0-100%)
+  const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  // 부드러운 프로그래스바 업데이트 시작 (requestAnimationFrame 사용)
+  const startSmoothUpdate = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const tick = () => {
+      if (audio.currentTime !== undefined) {
+        setCurrentTime(audio.currentTime);
+      }
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+    rafIdRef.current = requestAnimationFrame(tick);
+  };
+
+  // 부드러운 프로그래스바 업데이트 정지
+  const stopSmoothUpdate = () => {
+    if (rafIdRef.current) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+  };
+
+  return (
+    <div
+      className={`px-6 py-5 bg-slate-50 rounded-lg flex flex-col justify-start items-start gap-4 ${className}`}
+    >
+      <div className="self-stretch inline-flex justify-between items-center">
+        <div className="flex-1 flex justify-start items-center gap-3">
+          {/* 재생/일시정지 버튼 */}
+          <button
+            onClick={togglePlayPause}
+            disabled={isLoading}
+            className="w-12 h-12 bg-blue-500 rounded-3xl flex justify-center items-center cursor-pointer hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? (
+              <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            ) : isPlaying ? (
+              <Square width={20} height={20} strokeWidth={1.67} stroke="#FFFFFF" />
+            ) : (
+              <Play width={20} height={20} strokeWidth={1.67} stroke="#FFFFFF" />
+            )}
+          </button>
+
+          {/* 질문 정보 및 프로그래스바 영역 */}
+          <div className="flex-1 inline-flex flex-col justify-center items-start">
+            {/* 질문 번호 및 텍스트 */}
+            <div className="self-stretch inline-flex justify-start items-start gap-1">
+              <div className="justify-start text-slate-800 text-sm font-semibold leading-normal  whitespace-pre-line">
+                {questionNumber}
+              </div>
+              <div className="justify-start text-slate-800 text-sm font-semibold leading-normal  whitespace-pre-line">
+                {questionText}
+              </div>
+            </div>
+
+            {/* 프로그래스바 및 시간 표시 */}
+            <div className="self-stretch flex justify-between items-center gap-3 mt-2">
+              <ProgressBar percent={progressPercentage} onClick={handleProgressBarClick} />
+              <div className="w-20 text-right justify-start text-slate-800 text-xs font-normal leading-none">
+                {formatTime(currentTime)} / {formatTime(duration)}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <audio ref={audioRef} src={audioUrl} preload="metadata" />
+    </div>
+  );
+}

--- a/app/(anon)/reports/[id]/components/AudioReportViewer.tsx
+++ b/app/(anon)/reports/[id]/components/AudioReportViewer.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import AudioPlayer from '@/app/(anon)/reports/[id]/components/AudioPlayer';
+import QuestionItem from '@/app/(anon)/reports/[id]/components/QuestionItem';
+import Edit from '@/public/assets/icons/edit.svg';
+import X from '@/public/assets/icons/x.svg';
+import Check from '@/public/assets/icons/check.svg';
+
+interface AudioReportViewerProps {
+  reportId: string;
+}
+
+export default function AudioReportViewer({ reportId }: AudioReportViewerProps) {
+  const [report, setReport] = useState<any>(null);
+  const [selectedQuestion, setSelectedQuestion] = useState<any>(null);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editingTitle, setEditingTitle] = useState('');
+
+  // DB에서 리포트와 질문 데이터 가져오기
+  useEffect(() => {
+    const fetchReportData = async () => {
+      console.log('🔍 API 호출 시작:', `/api/reports/${reportId}`);
+
+      try {
+        const response = await fetch(`/api/reports/${reportId}`, {
+          credentials: 'include', // 쿠키 포함하여 인증 정보 전달
+        });
+
+        console.log('📡 API 응답 상태:', response.status, response.statusText);
+        console.log('📡 API 응답 헤더:', Object.fromEntries(response.headers.entries()));
+
+        const result = await response.json();
+        console.log('📄 API 응답 데이터:', result);
+
+        if (result.success) {
+          setReport(result.data);
+          // 첫 번째 질문을 기본 선택으로 설정
+          if (result.data.questions && result.data.questions.length > 0) {
+            setSelectedQuestion(result.data.questions[0]);
+          }
+        } else {
+          console.error('❌ API 응답 실패:', result.message);
+        }
+      } catch (error) {
+        console.error('💥 API 호출 에러:', error);
+      }
+    };
+
+    if (reportId) {
+      console.log('🚀 useEffect 실행, reportId:', reportId);
+      fetchReportData();
+    }
+  }, [reportId]);
+
+  // 질문 선택 핸들러
+  const handleQuestionSelect = (question: any) => {
+    setSelectedQuestion(question);
+  };
+
+  // 사용자 답변 업데이트 핸들러
+  const handleUserAnswerUpdate = (questionOrder: number, newUserAnswer: string) => {
+    if (report) {
+      const updatedQuestions = report.questions.map((question: any) =>
+        question.order === questionOrder ? { ...question, userAnswer: newUserAnswer } : question
+      );
+
+      setReport({
+        ...report,
+        questions: updatedQuestions,
+      });
+
+      // 선택된 질문도 업데이트
+      if (selectedQuestion && selectedQuestion.order === questionOrder) {
+        setSelectedQuestion({
+          ...selectedQuestion,
+          userAnswer: newUserAnswer,
+        });
+      }
+    }
+  };
+
+  // 제목 편집 시작 핸들러
+  const handleEditTitle = () => {
+    setIsEditingTitle(true);
+    setEditingTitle(report?.title || '');
+  };
+
+  // 제목 저장 핸들러
+  const handleSaveTitle = async () => {
+    if (!reportId || !editingTitle.trim()) return;
+
+    try {
+      // 서버에 제목 업데이트 요청
+      const response = await fetch(`/api/reports/${reportId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ title: editingTitle.trim() }),
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        if (result.success) {
+          // DB 업데이트 성공 시 로컬 상태도 업데이트
+          setReport({
+            ...report,
+            title: result.data.title,
+          });
+          setIsEditingTitle(false);
+          console.log('✅ 제목이 성공적으로 업데이트되었습니다.');
+        }
+      } else {
+        console.error('❌ 제목 업데이트 실패:', response.status);
+        // 실패 시 편집 모드 유지
+      }
+    } catch (error) {
+      console.error('💥 제목 업데이트 오류:', error);
+      // 에러 시 편집 모드 유지
+    }
+  };
+
+  // 제목 편집 취소 핸들러
+  const handleCancelTitle = () => {
+    setIsEditingTitle(false);
+    setEditingTitle('');
+  };
+
+  return (
+    <div className="self-stretch h-[1413px] px-16 py-8 bg-slate-50 inline-flex flex-col justify-start items-start gap-16">
+      {/* 파일명 헤더 */}
+      <div className="self-stretch flex flex-col justify-start items-start gap-2">
+        <div className="self-stretch inline-flex justify-start items-center gap-2">
+          {/* 파일명 */}
+          {isEditingTitle ? (
+            <input
+              type="text"
+              value={editingTitle}
+              onChange={(e) => setEditingTitle(e.target.value)}
+              className="text-center text-slate-800 text-3xl font-bold leading-normal border-2 border-blue-500 focus:outline-none focus:border-blue-600 px-2 rounded"
+              placeholder="제목을 입력하세요"
+              style={{ width: `${editingTitle.length + 4}ch` }}
+            />
+          ) : (
+            <div className="text-center text-slate-800 text-3xl font-bold leading-normal flex items-center">
+              {report?.title || '제목 없음'}
+            </div>
+          )}
+
+          {/* 편집 섹션 */}
+          <div className="flex items-center gap-2">
+            {isEditingTitle ? (
+              <>
+                {/* 저장 버튼 */}
+                <div className="cursor-pointer" onClick={handleSaveTitle}>
+                  <Check width={20} height={20} strokeWidth={0.5} stroke="#303030" />
+                </div>
+                {/* 취소 버튼 */}
+                <div className="cursor-pointer" onClick={handleCancelTitle}>
+                  <X width={20} height={20} strokeWidth={2.3} stroke="#303030" />
+                </div>
+              </>
+            ) : (
+              /* 수정버튼 */
+              <div className="cursor-pointer" onClick={handleEditTitle}>
+                <Edit width={20} height={20} strokeWidth={0.5} stroke="#303030" />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="self-stretch justify-start text-slate-500 text-base font-normal leading-tight">
+          음성 녹음을 기반으로 생성된 면접 스크립트를 통해 개선점을 제안받으세요
+        </div>
+      </div>
+
+      {/* 음성 재생 컴포넌트 */}
+      <div className="flex flex-col gap-6">
+        {/* 오디오 플레이어 */}
+        <div className="w-[840px] p-6 bg-white rounded-xl outline outline-1 outline-offset-[-1px] outline-slate-200 flex flex-col gap-5">
+          <div className="flex flex-col gap-3">
+            <div className="flex justify-between items-center">
+              <div className="text-slate-800 text-lg font-bold leading-snug">면접 음성 파일</div>
+              <div className="h-6 px-2 bg-green-100 rounded-xl flex justify-center items-center">
+                <div className="text-green-600 text-xs font-medium leading-none">분석 완료</div>
+              </div>
+            </div>
+            <div className="text-slate-500 text-sm font-normal leading-none">
+              질문을 클릭하여 음성파일을 확인해보세요.
+            </div>
+          </div>
+
+          {/* 음성 - 선택된 질문의 녹음 파일 사용 */}
+          {selectedQuestion && (
+            <AudioPlayer
+              key={`${reportId}-${selectedQuestion.order}`}
+              questionNumber={`Q${selectedQuestion.order}`}
+              questionText={selectedQuestion.question}
+              audioUrl={
+                selectedQuestion.recording
+                  ? `/assets/audios/${reportId}/${selectedQuestion.recording}`
+                  : '/assets/audios/2/recording_2_8.mp3'
+              }
+              className="self-stretch"
+            />
+          )}
+        </div>
+
+        {/* 질문 목록 */}
+        <div className="w-[840px] p-6 bg-white rounded-xl outline outline-1 outline-offset-[-1px] outline-slate-200 flex flex-col gap-4">
+          {/* 질문 목록 렌더링 (DB에서 가져온 데이터) */}
+          {report?.questions?.map((question: any) => (
+            <QuestionItem
+              key={question.id}
+              questionNumber={question.order}
+              questionText={question.question}
+              userAnswer={question.userAnswer}
+              sampleAnswer={question.sampleAnswer}
+              isExpanded={false}
+              showActions={false}
+              className="hover:outline hover:outline-2 hover:outline-offset-[-1px] hover:outline-blue-400"
+              reportId={parseInt(reportId)}
+              onQuestionSelect={() => handleQuestionSelect(question)}
+              onUserAnswerUpdate={handleUserAnswerUpdate}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(anon)/reports/[id]/components/ProgressBar.tsx
+++ b/app/(anon)/reports/[id]/components/ProgressBar.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+interface ProgressBarProps {
+  percent: number;
+  className?: string;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function ProgressBar({ percent, className = '', onClick }: ProgressBarProps) {
+  // percent는 0-100 사이의 값
+  const clampedPercent = Math.max(0, Math.min(percent, 100));
+
+  return (
+    <div className={`flex-1 flex justify-start items-center ${className}`}>
+      <div
+        className="relative flex w-full h-[6px] bg-[#E2E8F0] rounded-[3px] overflow-hidden cursor-pointer"
+        onClick={onClick}
+      >
+        <div
+          className="h-full bg-[#3B82F6]"
+          style={{
+            width: `${clampedPercent}%`,
+            transition: 'none',
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(anon)/reports/[id]/components/QuestionItem.tsx
+++ b/app/(anon)/reports/[id]/components/QuestionItem.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState } from 'react';
+import ArrowDown from '@/public/assets/icons/arrow-down.svg';
+import ArrowUp from '@/public/assets/icons/arrow-up.svg';
+
+interface QuestionItemProps {
+  questionNumber: number;
+  questionText: string;
+  userAnswer?: string;
+  sampleAnswer?: string;
+  isExpanded?: boolean;
+  showActions?: boolean;
+  className?: string;
+  reportId?: number;
+  onQuestionSelect?: () => void;
+  onUserAnswerUpdate?: (questionOrder: number, newUserAnswer: string) => void;
+}
+
+export default function QuestionItem({
+  questionNumber,
+  questionText,
+  userAnswer,
+  sampleAnswer,
+  isExpanded = false,
+  showActions = false,
+  className = '',
+  reportId,
+  onQuestionSelect,
+  onUserAnswerUpdate,
+}: QuestionItemProps) {
+  const [expanded, setExpanded] = useState(isExpanded);
+  const [showSampleAnswer, setShowSampleAnswer] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedAnswer, setEditedAnswer] = useState(userAnswer || '');
+
+  const toggleExpanded = () => {
+    const newExpanded = !expanded;
+    setExpanded(newExpanded);
+    // 축소할 때는 모범답안도 숨김
+    if (!newExpanded) {
+      setShowSampleAnswer(false);
+    }
+    // 질문 선택 시 AudioPlayer 업데이트
+    if (onQuestionSelect) {
+      onQuestionSelect();
+    }
+  };
+
+  const toggleSampleAnswer = () => {
+    setShowSampleAnswer(!showSampleAnswer);
+  };
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setEditedAnswer(userAnswer || '');
+    // 수정 모드 진입 시에는 AudioPlayer 업데이트하지 않음
+  };
+
+  const handleSave = async () => {
+    if (!reportId) return;
+
+    try {
+      const response = await fetch(
+        `/api/reports/${reportId}/questions/${questionNumber}/user-answer`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ userAnswer: editedAnswer }),
+        }
+      );
+
+      if (response.ok) {
+        setIsEditing(false);
+        // 부모 컴포넌트에 답변 업데이트 알림
+        if (onUserAnswerUpdate) {
+          onUserAnswerUpdate(questionNumber, editedAnswer);
+        }
+      } else {
+        console.error('답변 저장 실패');
+      }
+    } catch (error) {
+      console.error('답변 저장 오류:', error);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditedAnswer(userAnswer || '');
+  };
+
+  return (
+    <div
+      onClick={isEditing ? undefined : toggleExpanded}
+      className={`w-[792px] min-h-[56px] p-4 bg-slate-50 ${isEditing ? '' : 'cursor-pointer'} rounded-lg flex flex-col justify-start items-start gap-3 ${className}`}
+    >
+      {/* 질문 헤더 */}
+      <div className="self-stretch flex justify-start items-start gap-4">
+        {/* 질문 번호  */}
+        <div className="w-7 h-7 bg-blue-50 rounded outline outline-1 outline-offset-[-1px] outline-blue-500 flex justify-center items-center flex-shrink-0">
+          <div className="flex justify-center items-center text-blue-500 text-[12px] font-bold w-full h-full">
+            Q{questionNumber}
+          </div>
+        </div>
+
+        {/* 질문 텍스트와 화살표를 포함하는 영역 */}
+        <div className="flex-1 flex justify-between items-start gap-2">
+          {/* 질문 텍스트 */}
+          <div className="justify-start text-slate-800 text-sm font-semibold leading-normal whitespace-pre-line">
+            {questionText}
+          </div>
+
+          {/* 확장/축소 버튼 */}
+          <button
+            onClick={isEditing ? undefined : toggleExpanded}
+            className={`w-4 h-4 relative origin-top-left overflow-hidden ${isEditing ? 'cursor-default' : 'cursor-pointer'} flex-shrink-0`}
+          >
+            {expanded ? (
+              <ArrowUp width={16} height={16} strokeWidth={1.33} stroke="#303030" />
+            ) : (
+              <ArrowDown width={16} height={16} strokeWidth={1.33} stroke="#303030" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* 답변 내용 */}
+      {expanded && (
+        <>
+          {/* 사용자 답변 */}
+          {isEditing ? (
+            <div className="self-stretch flex flex-col gap-2">
+              <textarea
+                value={editedAnswer}
+                onChange={(e) => setEditedAnswer(e.target.value)}
+                className="w-full p-4 border border-gray-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                rows={4}
+                placeholder="답변을 입력하세요..."
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleSave();
+                  }}
+                  className="px-3 py-1.5 bg-blue-500 text-white text-xs font-medium rounded-lg hover:bg-blue-600 transition-colors cursor-pointer"
+                >
+                  저장
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCancel();
+                  }}
+                  className="px-3 py-1.5 bg-gray-300 text-gray-700 text-xs font-medium rounded-lg hover:bg-gray-400 transition-colors cursor-pointer"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="self-stretch justify-start text-gray-700 text-sm font-normal leading-snug">
+              {userAnswer || '사용자 답변이 존재하지 않습니다'}
+            </div>
+          )}
+
+          {/* 모범 답안 */}
+          {showSampleAnswer && (
+            <div className="self-stretch justify-start text-blue-500 text-sm font-normal leading-snug">
+              {sampleAnswer || '모범 답안이 존재하지 않습니다'}
+            </div>
+          )}
+
+          {/* 액션 버튼들 */}
+          {expanded && (
+            <div className="self-stretch inline-flex justify-end items-start gap-3">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleEdit();
+                }}
+                className="text-right justify-start text-stone-400 cursor-pointer text-xs font-medium leading-none hover:text-stone-600 transition-colors"
+              >
+                수정하기
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleSampleAnswer();
+                }}
+                className="justify-start text-xs font-medium cursor-pointer leading-none text-stone-400 hover:text-stone-600 transition-colors"
+              >
+                {showSampleAnswer ? '모범답안 숨기기' : '모범답안 보기'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(anon)/reports/[id]/components/ex.tsx
+++ b/app/(anon)/reports/[id]/components/ex.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <div></div>;
-}

--- a/app/(anon)/reports/[id]/page.tsx
+++ b/app/(anon)/reports/[id]/page.tsx
@@ -1,3 +1,6 @@
-export default function Page() {
-  return <div></div>;
+import AudioReportViewer from '@/app/(anon)/reports/[id]/components/AudioReportViewer';
+
+export default async function ReportPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <AudioReportViewer reportId={id} />;
 }

--- a/app/api/reports/[id]/questions/[order]/user-answer/route.ts
+++ b/app/api/reports/[id]/questions/[order]/user-answer/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { UpdateUserAnswerUseCase } from '@/backend/application/questions/usecases/UpdateUserAnswerUseCase';
+import { getUserFromSession } from '@/lib/auth/api-auth';
+
+const prisma = new PrismaClient();
+const updateUserAnswerUseCase = new UpdateUserAnswerUseCase(prisma);
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; order: string }> }
+) {
+  try {
+    // 사용자 인증 확인
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ success: false, message: '인증이 필요합니다.' }, { status: 401 });
+    }
+
+    const userId = Number(user.id);
+    const { id, order } = await params;
+    const reportId = parseInt(id, 10);
+    const questionOrder = parseInt(order, 10);
+
+    if (isNaN(reportId) || isNaN(questionOrder)) {
+      return NextResponse.json(
+        { success: false, message: '유효하지 않은 리포트 ID 또는 질문 순서입니다.' },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+    const { userAnswer } = body as { userAnswer: string };
+
+    if (!userAnswer || typeof userAnswer !== 'string') {
+      return NextResponse.json(
+        { success: false, message: '사용자 답변이 필요합니다.' },
+        { status: 400 }
+      );
+    }
+
+    // 리포트 소유권 확인
+    const report = await prisma.report.findUnique({
+      where: { id: reportId },
+      select: { userId: true },
+    });
+
+    if (!report) {
+      return NextResponse.json(
+        { success: false, message: '리포트를 찾을 수 없습니다.' },
+        { status: 404 }
+      );
+    }
+
+    if (report.userId !== userId) {
+      return NextResponse.json(
+        { success: false, message: '이 리포트에 대한 권한이 없습니다.' },
+        { status: 403 }
+      );
+    }
+
+    await updateUserAnswerUseCase.execute({
+      reportId,
+      order: questionOrder,
+      userAnswer,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: '사용자 답변이 성공적으로 업데이트되었습니다.',
+    });
+  } catch (error) {
+    console.error('사용자 답변 업데이트 오류:', error);
+
+    if (error instanceof Error && error.message.includes('not found')) {
+      return NextResponse.json(
+        { success: false, message: '질문을 찾을 수 없습니다.' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      { success: false, message: '서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/reports/[id]/route.ts
+++ b/app/api/reports/[id]/route.ts
@@ -101,15 +101,24 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 //조회
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    console.log('🔍 GET /api/reports/[id] 호출됨');
+    console.log('📡 요청 헤더:', Object.fromEntries(request.headers.entries()));
+
     // 사용자 인증 확인
     const user = await getUserFromSession();
+    console.log('👤 getUserFromSession 결과:', user);
+
     if (!user) {
+      console.log('❌ 인증 실패: 사용자 정보 없음');
       return NextResponse.json({ success: false, message: '인증이 필요합니다.' }, { status: 401 });
     }
 
     const userId = Number(user.id);
+    console.log('🆔 인증된 사용자 ID:', userId);
+
     const { id } = await params;
     const reportId = parseInt(id, 10);
+    console.log('📋 요청된 리포트 ID:', reportId);
 
     if (isNaN(reportId)) {
       return NextResponse.json(
@@ -119,8 +128,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const report = await getReportByIdUsecase.execute(reportId);
+    console.log('📄 조회된 리포트:', report);
 
     if (!report) {
+      console.log('❌ 리포트 없음');
       return NextResponse.json(
         { success: false, message: '리포트를 찾을 수 없습니다.' },
         { status: 404 }
@@ -128,12 +139,16 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // 리포트 소유권 확인
+    console.log('🔐 소유권 확인:', { reportUserId: report.userId, requestUserId: userId });
     if (report.userId !== userId) {
+      console.log('❌ 권한 없음: 다른 사용자의 리포트');
       return NextResponse.json(
         { success: false, message: '이 리포트에 대한 권한이 없습니다.' },
         { status: 403 }
       );
     }
+
+    console.log('✅ 권한 확인 통과');
 
     // 해당 리포트의 질문들도 함께 조회
     const questions = await getQuestionsUsecase.execute(reportId);

--- a/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
@@ -7,6 +7,7 @@ export interface SaveUserAnswerRequest {
   transcription: STTResponse;
 }
 
+// STT 응답을 받아 DB에 저장
 export class SaveUserAnswerUseCase {
   constructor(private prisma: PrismaClient) {}
 

--- a/backend/application/questions/usecases/UpdateUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/UpdateUserAnswerUseCase.ts
@@ -1,0 +1,37 @@
+import { PrismaClient } from '@prisma/client';
+
+export interface UpdateUserAnswerRequest {
+  reportId: number;
+  order: number;
+  userAnswer: string;
+}
+
+export class UpdateUserAnswerUseCase {
+  constructor(private prisma: PrismaClient) {}
+
+  async execute(request: UpdateUserAnswerRequest): Promise<void> {
+    const { reportId, order, userAnswer } = request;
+
+    // 해당 report와 order에 맞는 question이 존재하는지 확인
+    const question = await this.prisma.question.findFirst({
+      where: {
+        reportId,
+        order,
+      },
+    });
+
+    if (!question) {
+      throw new Error(`Question with reportId ${reportId} and order ${order} not found`);
+    }
+
+    // 질문의 userAnswer 필드 업데이트
+    await this.prisma.question.update({
+      where: { id: question.id },
+      data: {
+        userAnswer,
+      },
+    });
+
+    console.log(`✅ 사용자 답변이 업데이트되었습니다. Report ID: ${reportId}, Order: ${order}`);
+  }
+}

--- a/public/assets/icons/arrow-down.svg
+++ b/public/assets/icons/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.66658 6.66667L7.99992 10L11.3333 6.66667" stroke="#303030" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icons/arrow-up.svg
+++ b/public/assets/icons/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.3334 9.33333L8.00008 6L4.66675 9.33333" stroke="#303030" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 🔥 PR 제목  
> feat: Report 페이지 및 컴포넌트 구현


## ✨ 작업 내용

> UI 작업과 API 연동 모두 작업 완료

- Report 페이지 SSR로 구현
- 질문별 사용자의 음성을 재생할 수 있는 `AudioPlayer` 컴포넌트 구현
- 녹음 파일 재생하는 `ProgressBar` 컴포넌트 구현
- 면접 질문, 사용자의 답변, 모범답안을 확인할 수 있는 `QuestionItem `컴포넌트 구현
- 사용자 인증 로직 (getUserFromSession 함수) 추가

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 📸 스크린샷 / 시연 (선택)  
<img width="1470" height="879" alt="image" src="https://github.com/user-attachments/assets/633b3eb7-d2ed-4a2d-b3ad-78d55eefdc95" />
<img width="1394" height="850" alt="image" src="https://github.com/user-attachments/assets/072281bd-b763-4b9b-ad2a-ae380063d18e" />
<img width="905" height="255" alt="스크린샷 2025-08-20 오전 1 14 04" src="https://github.com/user-attachments/assets/1b9f2658-8630-4540-9864-1e0b53cb0caf" />


## 🙏 리뷰어에게 한마디  
> http://localhost:3000/reports/9 에서 테스트 가능!
