### PR TITLE
fix: 피드백 생성 전 상태가 COMPLETED로 전환되는 오류 수정

### DIFF
--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -157,16 +157,9 @@ export default function InterviewClient() {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
 
-        // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
-        // await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
-
-        // 피드백 생성이 성공적으로 완료되면 상태를 COMPLETED로 업데이트
-        // if (feedbackResult.status === 200) {
-        //   await updateReportStatus(reportId.toString(), 'COMPLETED');
-        // }
 
         router.push('/'); //마지막 질문인 경우
       } else {

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -152,21 +152,21 @@ export default function InterviewClient() {
         console.error('STT 처리 중 오류:', sttError);
       }
 
-      // 다음 질문으로 이동
+      // 마지막 질문인 경우
       if (currentOrder >= 10) {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
 
         // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
-        await updateReportStatus(reportId.toString(), 'ANALYZING');
+        // await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
 
         // 피드백 생성이 성공적으로 완료되면 상태를 COMPLETED로 업데이트
-        if (feedbackResult.status === 200) {
-          await updateReportStatus(reportId.toString(), 'COMPLETED');
-        }
+        // if (feedbackResult.status === 200) {
+        //   await updateReportStatus(reportId.toString(), 'COMPLETED');
+        // }
 
         router.push('/'); //마지막 질문인 경우
       } else {

--- a/backend/application/feedbacks/usecases/GenerateFeedbackUsecase.ts
+++ b/backend/application/feedbacks/usecases/GenerateFeedbackUsecase.ts
@@ -23,16 +23,5 @@ export class GenerateFeedbackUsecase {
       await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
       throw error;
     }
-    try {
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
-      const evaluation = await this.llmRepository.generateFeedback(dto);
-      await this.persistenceRepository.saveFeedback(evaluation);
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'COMPLETED');
-
-      return evaluation;
-    } catch (error) {
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
-      throw error;
-    }
   }
 }

--- a/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
@@ -34,14 +34,6 @@ export class SaveUserAnswerUseCase {
       },
     });
 
-    // Report 상태를 'COMPLETED'로 업데이트
-    await this.prisma.report.update({
-      where: { id: reportId },
-      data: {
-        status: 'COMPLETED',
-      },
-    });
-
     console.log(`✅ 사용자 답변이 저장되었습니다. Report ID: ${reportId}, Order: ${order}`);
   }
 }


### PR DESCRIPTION
## 🔥 PR 제목  
> fix: 피드백 생성 전 상태가 COMPLETED로 전환되는 오류 수정


## ✨ 작업 내용
- 첫 번째 질문(STT 저장) 직후 report.status가 COMPLETED로 변경되어 상태 처리 문제가 있었습니다.
- SaveUserAnswerUseCase 내에서 매 질문 저장마다 상태를 COMPLETED로 올리던 로직을 제거했습니다. 
- 상태 전이는 피드백 생성 플로우에서만 수행되도록 정리했습니다.


## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.



## 📸 스크린샷 / 로그
- SaveUserAnswerUseCase.ts 파일 중 상태를 처리하고 있던 라인
<img width="697" height="151" alt="Image" src="https://github.com/user-attachments/assets/ad937798-cacb-4048-923a-b83c94d839b2" />


## 🙏 리뷰어에게 한마디  
> 화이팅
