### PR TITLE
리포트 안에 회고 컴포넌트에서 수정하기 버튼을 누르면 나오는 저장 및 취소 버튼 추가

### DIFF
--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -15,8 +15,10 @@ import { QuestionTTSResponse } from '@/backend/application/questions/dtos/Questi
 import type { InterviewPhase } from '@/types/interview';
 import axios from 'axios';
 import { useReportStatusStore } from '@/stores/useReportStatusStore';
+import { useModalStore } from '@/stores/useModalStore';
 
 export default function InterviewClient() {
+  const { openModal } = useModalStore();
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const reportId = Number(id);
@@ -160,8 +162,7 @@ export default function InterviewClient() {
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
-
-        router.push('/'); //마지막 질문인 경우
+        openModal('reflection');
       } else {
         setCurrentOrder((o) => Math.min(10, o + 1));
       }

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -157,16 +157,9 @@ export default function InterviewClient() {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
 
-        // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
-        // await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
-
-        // 피드백 생성이 성공적으로 완료되면 상태를 COMPLETED로 업데이트
-        // if (feedbackResult.status === 200) {
-        //   await updateReportStatus(reportId.toString(), 'COMPLETED');
-        // }
 
         router.push('/'); //마지막 질문인 경우
       } else {

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -158,7 +158,8 @@ export default function InterviewClient() {
       if (currentOrder >= 10) {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
-
+        // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
+        await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -158,12 +158,20 @@ export default function InterviewClient() {
       if (currentOrder >= 10) {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
+
         // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
         await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
         openModal('reflection');
+
+        // 피드백 생성이 성공적으로 완료되면 상태를 COMPLETED로 업데이트
+        if (feedbackResult.status === 200) {
+          await updateReportStatus(reportId.toString(), 'COMPLETED');
+        }
+
+        router.push('/'); //마지막 질문인 경우
       } else {
         setCurrentOrder((o) => Math.min(10, o + 1));
       }

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -152,21 +152,21 @@ export default function InterviewClient() {
         console.error('STT 처리 중 오류:', sttError);
       }
 
-      // 다음 질문으로 이동
+      // 마지막 질문인 경우
       if (currentOrder >= 10) {
         const key = `interview:${reportId}:currentOrder`;
         localStorage.removeItem(key);
 
         // 피드백 생성 요청 보낼 때 상태를 ANALYZING으로 업데이트
-        await updateReportStatus(reportId.toString(), 'ANALYZING');
+        // await updateReportStatus(reportId.toString(), 'ANALYZING');
         // 피드백 생성
         const feedbackResult = await axios.post(`/api/reports/${reportId}/feedback`);
         console.log('피드백 생성 결과:', feedbackResult.status);
 
         // 피드백 생성이 성공적으로 완료되면 상태를 COMPLETED로 업데이트
-        if (feedbackResult.status === 200) {
-          await updateReportStatus(reportId.toString(), 'COMPLETED');
-        }
+        // if (feedbackResult.status === 200) {
+        //   await updateReportStatus(reportId.toString(), 'COMPLETED');
+        // }
 
         router.push('/'); //마지막 질문인 경우
       } else {

--- a/app/(anon)/interview/[id]/page.tsx
+++ b/app/(anon)/interview/[id]/page.tsx
@@ -1,11 +1,13 @@
 import InterviewClient from '@/app/(anon)/interview/[id]/components/InterviewClient';
 import CheckInterview from '@/app/(anon)/interview/[id]/components/precheck/CheckInterview';
+import ReflectionModal from '@/app/(anon)/interview/components/modal/ReflectionModal';
 
 export default function Page() {
   return (
     <>
       <CheckInterview />
       <InterviewClient />
+      <ReflectionModal />
     </>
   );
 }

--- a/app/(anon)/interview/components/modal/ReflectionModal.tsx
+++ b/app/(anon)/interview/components/modal/ReflectionModal.tsx
@@ -2,13 +2,21 @@
 import Modal from '@/app/(anon)/components/modal/Modal';
 import ModalOverlay from '@/app/(anon)/components/modal/ModalOverlay';
 import { useModalStore } from '@/stores/useModalStore';
+import { useRouter } from 'next/navigation';
 
 export default function ReflectionModal() {
-  const { isOpen, closeModal } = useModalStore();
+  const router = useRouter();
+  const { isOpen, currentStep, closeModal, replaceModal } = useModalStore();
+  if (!isOpen || currentStep !== 'reflection') return null;
 
-  const NextButton = () => (
+  const NextButton = ({ onClick }: { onClick?: () => void }) => (
     <button className="self-stretch h-11 bg-[#3B82F6] rounded-lg inline-flex justify-center items-center">
-      <div className="text-white text-sm font-semibold cursor-pointer" onClick={closeModal}>
+      <div
+        className="text-white text-sm font-semibold cursor-pointer"
+        onClick={() => {
+          handleReplaceModal();
+        }}
+      >
         다음
       </div>
     </button>
@@ -16,11 +24,21 @@ export default function ReflectionModal() {
 
   const SkipButton = () => (
     <button className="self-stretch h-11 bg-[#FFFFFF] rounded-lg inline-flex justify-center items-center">
-      <div className="text-[#64748B] text-sm font-semibold cursor-pointer" onClick={closeModal}>
+      <div
+        className="text-[#64748B] text-sm font-semibold cursor-pointer"
+        onClick={() => {
+          closeModal();
+          router.push('/');
+        }}
+      >
         건너뛰기
       </div>
     </button>
   );
+
+  const handleReplaceModal = () => {
+    replaceModal('video');
+  };
 
   return (
     <ModalOverlay isOpen={isOpen} onClose={closeModal}>
@@ -41,7 +59,7 @@ export default function ReflectionModal() {
               <SkipButton />
             </div>
             <div className="flex-1 h-11 px-5 bg-blue-500 rounded-lg flex justify-center items-center">
-              <NextButton />
+              <NextButton onClick={handleReplaceModal} />
             </div>
           </div>
         }

--- a/app/(anon)/interview/components/modal/ReflectionModal.tsx
+++ b/app/(anon)/interview/components/modal/ReflectionModal.tsx
@@ -2,39 +2,61 @@
 import Modal from '@/app/(anon)/components/modal/Modal';
 import ModalOverlay from '@/app/(anon)/components/modal/ModalOverlay';
 import { useModalStore } from '@/stores/useModalStore';
-import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
 
 export default function ReflectionModal() {
-  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const reportId = Number(id);
+  const [reflection, setReflection] = useState<string>('');
   const { isOpen, currentStep, closeModal, replaceModal } = useModalStore();
   if (!isOpen || currentStep !== 'reflection') return null;
 
-  const NextButton = ({ onClick }: { onClick?: () => void }) => (
-    <button className="self-stretch h-11 bg-[#3B82F6] rounded-lg inline-flex justify-center items-center">
-      <div
-        className="text-white text-sm font-semibold cursor-pointer"
-        onClick={() => {
-          handleReplaceModal();
-        }}
-      >
-        다음
-      </div>
+  const NextButton = ({ onClick, className }: { onClick?: () => void; className?: string }) => (
+    <button
+      type="button"
+      className={`flex-1 h-11 px-5 rounded-lg inline-flex justify-center items-center ${className ?? ''}`}
+      onClick={() => {
+        if (onClick) {
+          onClick();
+        } else {
+          console.error('NextButton onClick is not defined');
+        }
+      }}
+    >
+      <div className="text-white text-sm font-semibold">다음</div>
     </button>
   );
 
-  const SkipButton = () => (
-    <button className="self-stretch h-11 bg-[#FFFFFF] rounded-lg inline-flex justify-center items-center">
-      <div
-        className="text-[#64748B] text-sm font-semibold cursor-pointer"
-        onClick={() => {
-          closeModal();
-          router.push('/');
-        }}
-      >
-        건너뛰기
-      </div>
+  const SkipButton = ({ onClick, className }: { onClick?: () => void; className?: string }) => (
+    <button
+      type="button"
+      className={`flex-1 h-11 px-5 rounded-lg inline-flex justify-center items-center ${className ?? ''}`}
+      onClick={() => {
+        if (onClick) {
+          onClick();
+        } else {
+          console.error('SkipButton onClick is not defined');
+        }
+      }}
+    >
+      <div className="text-[#64748B] text-sm font-semibold">건너뛰기</div>
     </button>
   );
+
+  const handleSubmitReflection = async () => {
+    try {
+      await axios.put(`/api/reports/${reportId}`, {
+        reflection: reflection,
+      });
+      console.log('reflection submitted');
+      replaceModal('video');
+    } catch (error) {
+      console.error(error);
+      replaceModal('video');
+    }
+  };
 
   const handleReplaceModal = () => {
     replaceModal('video');
@@ -51,16 +73,17 @@ export default function ReflectionModal() {
           <textarea
             className="w-[432px] h-[132px] self-stretch px-4 py-3 bg-slate-50 rounded-lg outline outline-1 outline-offset-[-1px] outline-slate-300 resize-none align-top"
             placeholder="모의면접 진행 후 느낀점을 자유롭게 적어주세요."
+            value={reflection}
+            onChange={(e) => setReflection(e.target.value)}
           />
         }
         buttons={
-          <div className="self-stretch inline-flex justify-center items-center gap-3">
-            <div className="flex-1 h-11 px-5 bg-white rounded-lg outline outline-1 outline-offset-[-1px] outline-slate-300 flex justify-center items-center gap-1">
-              <SkipButton />
-            </div>
-            <div className="flex-1 h-11 px-5 bg-blue-500 rounded-lg flex justify-center items-center">
-              <NextButton onClick={handleReplaceModal} />
-            </div>
+          <div className="w-full inline-flex justify-center items-center gap-3">
+            <SkipButton
+              className="bg-white outline outline-1 outline-offset-[-1px] outline-slate-300"
+              onClick={handleReplaceModal}
+            />
+            <NextButton className="bg-blue-500" onClick={handleSubmitReflection} />
           </div>
         }
       />

--- a/app/(anon)/interview/components/modal/ReflectionModal.tsx
+++ b/app/(anon)/interview/components/modal/ReflectionModal.tsx
@@ -3,17 +3,21 @@ import Modal from '@/app/(anon)/components/modal/Modal';
 import ModalOverlay from '@/app/(anon)/components/modal/ModalOverlay';
 import { useModalStore } from '@/stores/useModalStore';
 
-interface ReflectionModalProps {
-  reflection: string;
-}
-
-export default function ReflectionModal({ reflection }: ReflectionModalProps) {
+export default function ReflectionModal() {
   const { isOpen, closeModal } = useModalStore();
 
-  const ModalButton = () => (
+  const NextButton = () => (
     <button className="self-stretch h-11 bg-[#3B82F6] rounded-lg inline-flex justify-center items-center">
       <div className="text-white text-sm font-semibold cursor-pointer" onClick={closeModal}>
-        확인
+        다음
+      </div>
+    </button>
+  );
+
+  const SkipButton = () => (
+    <button className="self-stretch h-11 bg-[#FFFFFF] rounded-lg inline-flex justify-center items-center">
+      <div className="text-[#64748B] text-sm font-semibold cursor-pointer" onClick={closeModal}>
+        건너뛰기
       </div>
     </button>
   );
@@ -26,17 +30,21 @@ export default function ReflectionModal({ reflection }: ReflectionModalProps) {
         subTitle="회고는 면접 직후에 하면 더 오래 기억에 남아요."
         onClose={closeModal}
         body={
-          <div className="w-full text-left bg-slate-50 p-4 rounded-lg text-sm text-slate-600">
-            <p className="font-semibold mb-2">다음과 같은 파일들을 업로드해주세요</p>
-            <ul className="list-disc list-inside space-y-1">
-              <li>이력서 (경력, 프로젝트 경험 포함)</li>
-              <li>자기소개서</li>
-              <li>상세한 채용공고 (업무 내용, 기술 스택 등)</li>
-              <li>포트폴리오</li>
-            </ul>
+          <textarea
+            className="w-[432px] h-[132px] self-stretch px-4 py-3 bg-slate-50 rounded-lg outline outline-1 outline-offset-[-1px] outline-slate-300 resize-none align-top"
+            placeholder="모의면접 진행 후 느낀점을 자유롭게 적어주세요."
+          />
+        }
+        buttons={
+          <div className="self-stretch inline-flex justify-center items-center gap-3">
+            <div className="flex-1 h-11 px-5 bg-white rounded-lg outline outline-1 outline-offset-[-1px] outline-slate-300 flex justify-center items-center gap-1">
+              <SkipButton />
+            </div>
+            <div className="flex-1 h-11 px-5 bg-blue-500 rounded-lg flex justify-center items-center">
+              <NextButton />
+            </div>
           </div>
         }
-        buttons={<ModalButton />}
       />
     </ModalOverlay>
   );

--- a/app/(anon)/reports/[id]/components/AIFeedback.tsx
+++ b/app/(anon)/reports/[id]/components/AIFeedback.tsx
@@ -2,11 +2,13 @@
 import React, { useEffect } from 'react';
 import BrainIcon from '@/public/assets/icons/brain.svg';
 import { LoadingSpinner } from '@/app/(anon)/components/loading/LoadingSpinner';
+import { useReportStatusStore } from '@/stores/useReportStatusStore';
 
 export default function AIFeedback({ reportId }: { reportId: number }) {
   const [feedback, setFeedback] = React.useState<any>(null);
   const [loading, setLoading] = React.useState(true);
   const [isCompleted, setIsCompleted] = React.useState(false);
+  const { updateReportStatus } = useReportStatusStore();
 
   const isFeedbackComplete = (feedbackData: any): boolean => {
     return (
@@ -37,6 +39,8 @@ export default function AIFeedback({ reportId }: { reportId: number }) {
           if (isFeedbackComplete(data)) {
             setFeedback(data);
             setIsCompleted(true);
+            // 피드백이 완성되면 리포트 상태를 COMPLETED로 업데이트
+            updateReportStatus(reportId.toString(), 'COMPLETED');
           }
         } else if (response.status === 409) {
           console.log('Report is not completed');

--- a/app/(anon)/reports/[id]/components/AIFeedback.tsx
+++ b/app/(anon)/reports/[id]/components/AIFeedback.tsx
@@ -64,7 +64,7 @@ export default function AIFeedback({ reportId }: { reportId: number }) {
   }, [reportId]);
 
   return (
-    <div className="w-100 relative rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800 font-['Inter']">
+    <div className="w-100 min-h-[185px] relative rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800 font-['Inter']">
       <div className="self-stretch flex flex-row items-center justify-start gap-2">
         <BrainIcon className="w-5 h-5 relative overflow-hidden flex-shrink-0 text-[#3B82F6]" />
         <b className="flex-1 relative leading-[21.6px]">AI 피드백</b>

--- a/app/(anon)/reports/[id]/components/AIFeedback.tsx
+++ b/app/(anon)/reports/[id]/components/AIFeedback.tsx
@@ -2,13 +2,11 @@
 import React, { useEffect } from 'react';
 import BrainIcon from '@/public/assets/icons/brain.svg';
 import { LoadingSpinner } from '@/app/(anon)/components/loading/LoadingSpinner';
-import { useReportStatusStore } from '@/stores/useReportStatusStore';
 
 export default function AIFeedback({ reportId }: { reportId: number }) {
   const [feedback, setFeedback] = React.useState<any>(null);
   const [loading, setLoading] = React.useState(true);
   const [isCompleted, setIsCompleted] = React.useState(false);
-  const { updateReportStatus } = useReportStatusStore();
 
   const isFeedbackComplete = (feedbackData: any): boolean => {
     return (
@@ -39,8 +37,6 @@ export default function AIFeedback({ reportId }: { reportId: number }) {
           if (isFeedbackComplete(data)) {
             setFeedback(data);
             setIsCompleted(true);
-            // 피드백이 완성되면 리포트 상태를 COMPLETED로 업데이트
-            updateReportStatus(reportId.toString(), 'COMPLETED');
           }
         } else if (response.status === 409) {
           console.log('Report is not completed');
@@ -68,7 +64,7 @@ export default function AIFeedback({ reportId }: { reportId: number }) {
   }, [reportId]);
 
   return (
-    <div className="w-100 min-h-[185px] relative rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800 font-['Inter']">
+    <div className="w-100 relative rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800 font-['Inter']">
       <div className="self-stretch flex flex-row items-center justify-start gap-2">
         <BrainIcon className="w-5 h-5 relative overflow-hidden flex-shrink-0 text-[#3B82F6]" />
         <b className="flex-1 relative leading-[21.6px]">AI 피드백</b>

--- a/app/(anon)/reports/[id]/components/Reflection.tsx
+++ b/app/(anon)/reports/[id]/components/Reflection.tsx
@@ -13,55 +13,102 @@ export default function Reflection({
   reflection: string;
 }) {
   const [isLoading, setIsLoading] = useState(true);
-  const [text, setText] = useState(reflection ?? 'ex) 이번 면접에서 가장 잘한 점');
+  const [text, setText] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+
+  // test api call
+  useEffect(() => {
+    const dbFetch = async () => {
+      const result = await axios.get(`/api/reports/${reportId}`, {
+        data: reflection,
+      });
+      setText(result.data.data.reflection ?? 'ex) 이번 면접에서 가장 잘한 점');
+      setIsLoading(false);
+      console.log(result.data.data.reflection);
+    };
+    dbFetch();
+  }, []);
 
   useEffect(() => {
     setIsLoading(false);
   }, [reflection]);
 
-  const handleSaveClick = async () => {
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
     try {
       await axios.put(`/api/reports/${reportId}`, {
         reflection: text,
       });
+      setIsEditing(false);
     } catch (error) {
       console.error(error);
     }
   };
 
-  if (isLoading) return <LoadingSpinner />;
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
 
   return (
-    <div className="w-[450px] rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800">
+    <div className="w-[450px] min-h-[349px] rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800">
       <div className="self-stretch flex flex-row items-center justify-start gap-2">
         <MessageSquareIcon className="w-5 h-5 relative overflow-hidden flex-shrink-0 text-[#3B82F6]" />
         <b className="flex-1 relative leading-[21.6px] text-[#1E293B]">면접 회고</b>
       </div>
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <div className="self-stretch flex flex-col items-start justify-start gap-5 text-sm">
+          <div className="self-stretch flex flex-col items-start justify-start gap-[6px]">
+            <div className="self-stretch relative leading-[16.8px] font-medium text-[##374151]">
+              면접에서 느낀 생각과 감정을 솔직하게 기록해보세요.
+            </div>
 
-      <div className="self-stretch flex flex-col items-start justify-start gap-5 text-sm">
-        <div className="self-stretch flex flex-col items-start justify-start gap-[6px]">
-          <div className="self-stretch relative leading-[16.8px] font-medium text-[##374151]">
-            면접에서 느낀 생각과 감정을 솔직하게 기록해보세요.
+            <textarea
+              className="w-full min-h-48 p-3 bg-slate-50 rounded-md border border-slate-200 outline-none focus:border-slate-300 text-slate-700 placeholder-slate-400"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              disabled={!isEditing}
+            />
           </div>
 
-          <textarea
-            className="w-full min-h-48 p-3 bg-slate-50 rounded-md border border-slate-200 outline-none focus:border-slate-300 text-slate-700 placeholder-slate-400"
-            placeholder="ex) 이번 면접에서 가장 잘한 점"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
+          {isEditing ? (
+            <div className="flex gap-2">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSave();
+                }}
+                className="px-3 py-1.5 bg-blue-500 text-white text-xs font-medium rounded-lg hover:bg-blue-600 transition-colors cursor-pointer"
+              >
+                저장
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCancel();
+                }}
+                className="px-3 py-1.5 bg-gray-300 text-gray-700 text-xs font-medium rounded-lg hover:bg-gray-400 transition-colors cursor-pointer"
+              >
+                취소
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="text-xs font-medium self-end text-slate-400 hover:text-slate-500 transition-colors"
+              onClick={() => {
+                handleEdit();
+              }}
+            >
+              수정하기
+            </button>
+          )}
         </div>
-
-        <button
-          type="button"
-          className="text-xs font-medium self-end text-slate-400 hover:text-slate-500 transition-colors"
-          onClick={() => {
-            handleSaveClick();
-          }}
-        >
-          수정하기
-        </button>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/(anon)/reports/[id]/components/Reflection.tsx
+++ b/app/(anon)/reports/[id]/components/Reflection.tsx
@@ -53,22 +53,26 @@ export default function Reflection({
   };
 
   return (
-    <div className="w-[450px] min-h-[349px] rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 gap-5 text-left text-lg text-slate-800">
-      <div className="self-stretch flex flex-row items-center justify-start gap-2">
+    <div
+      className={`w-[450px] h-[349px] gap-5 rounded-xl bg-white border border-slate-200 box-border flex flex-col items-start justify-start p-6 ${isEditing ? 'pb-4' : 'pb-6'} text-left text-lg text-slate-800`}
+    >
+      <div className="self-stretch flex flex-row items-center justify-start gap-2 mt-[6px]">
         <MessageSquareIcon className="w-5 h-5 relative overflow-hidden flex-shrink-0 text-[#3B82F6]" />
-        <b className="flex-1 relative leading-[21.6px] text-[#1E293B]">면접 회고</b>
+        <b className="flex-1 relative h-[22px] leading-[21.6px] text-[#1E293B]">면접 회고</b>
       </div>
       {isLoading ? (
         <LoadingSpinner />
       ) : (
-        <div className="self-stretch flex flex-col items-start justify-start gap-5 text-sm">
+        <div
+          className={`self-stretch flex flex-col items-start justify-start ${isEditing ? 'gap-4' : 'gap-5'} text-sm mb-[6px]`}
+        >
           <div className="self-stretch flex flex-col items-start justify-start gap-[6px]">
             <div className="self-stretch relative leading-[16.8px] font-medium text-[##374151]">
               면접에서 느낀 생각과 감정을 솔직하게 기록해보세요.
             </div>
 
             <textarea
-              className="w-full min-h-48 p-3 bg-slate-50 rounded-md border border-slate-200 outline-none focus:border-slate-300 text-slate-700 placeholder-slate-400"
+              className="w-full h-47 p-3 bg-slate-50 rounded-md border border-slate-200 outline-none focus:border-slate-300 text-slate-700 placeholder-slate-400"
               value={text}
               onChange={(e) => setText(e.target.value)}
               disabled={!isEditing}

--- a/backend/application/feedbacks/usecases/GenerateFeedbackUsecase.ts
+++ b/backend/application/feedbacks/usecases/GenerateFeedbackUsecase.ts
@@ -23,16 +23,5 @@ export class GenerateFeedbackUsecase {
       await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
       throw error;
     }
-    try {
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
-      const evaluation = await this.llmRepository.generateFeedback(dto);
-      await this.persistenceRepository.saveFeedback(evaluation);
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'COMPLETED');
-
-      return evaluation;
-    } catch (error) {
-      await this.updateReportStatusUsecase.execute(dto.reportId, 'ANALYZING');
-      throw error;
-    }
   }
 }

--- a/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
@@ -34,14 +34,6 @@ export class SaveUserAnswerUseCase {
       },
     });
 
-    // Report 상태를 'COMPLETED'로 업데이트
-    await this.prisma.report.update({
-      where: { id: reportId },
-      data: {
-        status: 'COMPLETED',
-      },
-    });
-
     console.log(`✅ 사용자 답변이 저장되었습니다. Report ID: ${reportId}, Order: ${order}`);
   }
 }


### PR DESCRIPTION
## 🔥 PR 제목  
> 리포트 안에 회고 컴포넌트에서 수정하기 버튼을 누르면 나오는 저장 및 취소 버튼 추가


## ✨ 작업 내용
- 수정하기 버튼을 누르면 저장 및 취소 버튼이 나오도록 UI 수정
- 저장을 누르면 API POST 호출로 DB에 reflection에 반영되도록 설정


## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 📸 스크린샷 / 시연 (선택)  
- 변경 전 컴포넌트
<img width="615" height="480" alt="스크린샷 2025-08-22 오후 2 21 35" src="https://github.com/user-attachments/assets/1828edd5-ca44-429e-a2ea-a9e4e3140431" />
- 변경 전 DB
<img width="733" height="27" alt="스크린샷 2025-08-22 오후 2 22 25" src="https://github.com/user-attachments/assets/bf495685-74f6-4d3d-b504-f507d82f7dbf" />
- 수정하기 버튼 클릭 시 저장 및 취소 버튼 추가
<img width="615" height="480" alt="스크린샷 2025-08-22 오후 2 21 39" src="https://github.com/user-attachments/assets/5c435a90-8adf-4c6f-945d-66c52fc9a96f" />
- 저장 클릭 시 컴포넌트 반영
<img width="619" height="474" alt="스크린샷 2025-08-22 오후 2 22 46" src="https://github.com/user-attachments/assets/96b6094e-0762-4403-b7a6-ee8826a9e382" />
- 저장 클릭 시 DB 반영
<img width="733" height="27" alt="스크린샷 2025-08-22 오후 2 22 39" src="https://github.com/user-attachments/assets/64fdbec9-4e5e-4cd2-935e-43339f037baf" />
- 취소 시엔 다시 수정하기 버튼만 나타남
<img width="615" height="480" alt="스크린샷 2025-08-22 오후 2 21 35" src="https://github.com/user-attachments/assets/287e6d40-2671-4c6e-8a3e-22f4954a40dd" />


