### PR TITLE
feat: 면접 환경 개선 및 질문 순서 로컬 스토리지에 저장

### DIFF
--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -182,7 +182,7 @@ export default function InterviewClient() {
         <section className="relative flex-1 min-w-0 h-full bg-[#F1F5F9] flex flex-col items-center justify-between">
           <audio ref={setAudioElementRef} className="hidden" playsInline />
           <AiAvatar ttsAudio={ttsAudioEl} playing={isPlaying} />
-          <Question text={currentQuestionText} />
+          <Question active={isPlaying} text={currentQuestionText} />
         </section>
         {/* Right: 사용자 영역 */}
         <section className="relative flex-1 min-w-0 h-full bg-[#FAFBFC] flex flex-col items-center justify-between gap-[24px]">

--- a/app/(anon)/interview/[id]/components/avatar/Question.tsx
+++ b/app/(anon)/interview/[id]/components/avatar/Question.tsx
@@ -10,7 +10,7 @@ interface QuestionProps {
 export default function Question({ text }: QuestionProps) {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] flex flex-col">
+    <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] flex flex-col cursor-default">
       <div className="flex justify-between items-center p-4 ">
         <div className="flex items-center gap-[8px]">
           <MessageCircle width={16} height={16} stroke="#3B82F6" />

--- a/app/(anon)/interview/[id]/components/avatar/Question.tsx
+++ b/app/(anon)/interview/[id]/components/avatar/Question.tsx
@@ -8,7 +8,7 @@ interface QuestionProps {
 }
 
 export default function Question({ text }: QuestionProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   return (
     <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] flex flex-col cursor-default">
       <div className="flex justify-between items-center p-4 ">

--- a/app/(anon)/interview/[id]/components/avatar/Question.tsx
+++ b/app/(anon)/interview/[id]/components/avatar/Question.tsx
@@ -1,20 +1,27 @@
 'use client';
 import MessageCircle from '@/public/assets/icons/message-circle.svg';
 import ArrowUp from '@/public/assets/icons/arrow-up.svg';
-import { useState } from 'react';
+import { act, useState } from 'react';
 
 interface QuestionProps {
   text: string;
+  active: boolean;
 }
 
-export default function Question({ text }: QuestionProps) {
+export default function Question({ text, active }: QuestionProps) {
   const [isOpen, setIsOpen] = useState(true);
   return (
-    <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] flex flex-col cursor-default">
+    <div
+      className={`absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border ${active ? 'border-[#3B82F6] shadow-[0px_4px_16px_0px_rgba(59,130,246,0.25)]' : 'border-[#E2E8F0]'}  flex flex-col cursor-default`}
+    >
       <div className="flex justify-between items-center p-4 ">
         <div className="flex items-center gap-[8px]">
-          <MessageCircle width={16} height={16} stroke="#3B82F6" />
-          <p className="text-[14px] text-[#3B82F6] font-semibold">질문</p>
+          <MessageCircle width={16} height={16} stroke={active ? '#3B82F6' : '#94A3B8'} />
+          <p
+            className={`text-[14px] ${active ? 'text-[#3B82F6]' : 'text-[#94A3B8]'} font-semibold`}
+          >
+            질문
+          </p>
         </div>
         <div
           onClick={() => setIsOpen(!isOpen)}

--- a/app/(anon)/interview/[id]/components/avatar/Question.tsx
+++ b/app/(anon)/interview/[id]/components/avatar/Question.tsx
@@ -1,18 +1,52 @@
 'use client';
 import MessageCircle from '@/public/assets/icons/message-circle.svg';
+import ArrowUp from '@/public/assets/icons/arrow-up.svg';
+import ArrowDown from '@/public/assets/icons/arrow-down.svg';
+import { useState } from 'react';
 
 interface QuestionProps {
   text: string;
 }
 
 export default function Question({ text }: QuestionProps) {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] p-4 rounded-[8px] bg-white border border-[#E2E8F0] gap-[8px] flex flex-col">
-      <div className="flex items-center gap-[8px]">
-        <MessageCircle width={16} height={16} stroke="#3B82F6" />
-        <p className="text-[12px] text-[#3B82F6] font-semibold">질문</p>
+    <div className="absolute bottom-[52px] w-[calc(100%-104px)] mx-[52px] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] flex flex-col">
+      <div className="flex justify-between items-center p-4 ">
+        <div className="flex items-center gap-[8px]">
+          <MessageCircle width={16} height={16} stroke="#3B82F6" />
+          <p className="text-[14px] text-[#3B82F6] font-semibold">질문</p>
+        </div>
+        <div
+          onClick={() => setIsOpen(!isOpen)}
+          className="bg-white rounded-[6px] w-[32px] h-[32px] border border-[#E2E8F0] flex items-center justify-center cursor-pointer"
+        >
+          <span
+            className={`will-change-transform transform-gpu origin-center transition-transform duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
+              isOpen ? 'rotate-0' : 'rotate-180'
+            }`}
+          >
+            <ArrowUp width={16} height={16} strokeWidth={1.3} />
+          </span>
+        </div>
       </div>
-      <p className="text-[14px] leading-[22px] text-[#334155] font-medium">{text}</p>
+      {/* Smooth height + translate animation upward */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div
+            className={`p-4 bg-white rounded-b-[8px] will-change-transform transition-all duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
+              isOpen ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'
+            }`}
+            style={{ transitionDelay: isOpen ? '50ms' : '0ms' }}
+          >
+            <p className="text-[14px] leading-[22px] text-[#334155] font-medium">{text}</p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/(anon)/interview/[id]/components/avatar/Question.tsx
+++ b/app/(anon)/interview/[id]/components/avatar/Question.tsx
@@ -1,7 +1,6 @@
 'use client';
 import MessageCircle from '@/public/assets/icons/message-circle.svg';
 import ArrowUp from '@/public/assets/icons/arrow-up.svg';
-import ArrowDown from '@/public/assets/icons/arrow-down.svg';
 import { useState } from 'react';
 
 interface QuestionProps {
@@ -30,7 +29,6 @@ export default function Question({ text }: QuestionProps) {
           </span>
         </div>
       </div>
-      {/* Smooth height + translate animation upward */}
       <div
         className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
           isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
@@ -38,7 +36,7 @@ export default function Question({ text }: QuestionProps) {
       >
         <div className="overflow-hidden">
           <div
-            className={`p-4 bg-white rounded-b-[8px] will-change-transform transition-all duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
+            className={`p-4 bg-white rounded-b-[8px] border-t border-[#E2E8F0] will-change-transform transition-all duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
               isOpen ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'
             }`}
             style={{ transitionDelay: isOpen ? '50ms' : '0ms' }}

--- a/app/(anon)/interview/[id]/components/bottom/BottomSection.tsx
+++ b/app/(anon)/interview/[id]/components/bottom/BottomSection.tsx
@@ -16,14 +16,14 @@ export default function BottomSection({
   nextLabel = '다음 질문',
 }: BottomSectionProps) {
   return (
-    <section className="relative flex items-center px-[24px] py-[16px] border-t border-slate-200 bg-[#F8FAFC]">
+    <section className="relative flex items-center px-[24px] py-[16px] border-t border-slate-200 bg-[#F8FAFC] cursor-default">
       <p className="absolute left-1/2 -translate-x-1/2 text-[#64748B] text-[12px] font-medium">
         질문 {currentQuestion}/{totalQuestions}
       </p>
       <button
         onClick={onNext}
         disabled={isDisabled}
-        className="ml-auto inline-flex items-center gap-[8px] px-[16px] py-[10px] rounded-[8px] bg-[#3B82F6] text-white text-[14px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[#2563EB]"
+        className="ml-auto inline-flex items-center gap-[8px] px-[16px] py-[10px] rounded-[8px] bg-[#3B82F6] text-white text-[14px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[#2563EB] cursor-pointer"
       >
         {nextLabel}
         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">

--- a/app/(anon)/interview/[id]/components/bottom/BottomSection.tsx
+++ b/app/(anon)/interview/[id]/components/bottom/BottomSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+
 interface BottomSectionProps {
   currentQuestion: number;
   totalQuestions: number;
@@ -15,10 +17,17 @@ export default function BottomSection({
   isDisabled,
   nextLabel = '다음 질문',
 }: BottomSectionProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   return (
     <section className="relative flex items-center px-[24px] py-[16px] border-t border-slate-200 bg-[#F8FAFC] cursor-default">
-      <p className="absolute left-1/2 -translate-x-1/2 text-[#64748B] text-[12px] font-medium">
-        질문 {currentQuestion}/{totalQuestions}
+      <p
+        className="absolute left-1/2 -translate-x-1/2 text-[#64748B] text-[12px] font-medium"
+        suppressHydrationWarning
+      >
+        질문 {mounted ? currentQuestion : '-'} / {totalQuestions}
       </p>
       <button
         onClick={onNext}

--- a/app/(anon)/interview/[id]/components/top/TopSection.tsx
+++ b/app/(anon)/interview/[id]/components/top/TopSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Timer from '@/app/(anon)/interview/[id]/components/top/Timer';
-import WaveAnimation from '@/public/assets/icons/wave-animation.svg';
 
 interface TopSectionProps {
   running: boolean;
@@ -22,23 +21,6 @@ export default function TopSection({ running, duration, onComplete }: TopSection
         >
           녹음 중
         </p>
-        {running ? (
-          <WaveAnimation
-            width={16}
-            height={16}
-            fill="#3B82F6"
-            strokeWidth={0.8}
-            className="text-[#3B82F6]"
-          />
-        ) : (
-          <WaveAnimation
-            width={16}
-            height={16}
-            fill="#E2E8F0"
-            strokeWidth={0.8}
-            className="text-[#E2E8F0]"
-          />
-        )}
       </div>
     </section>
   );

--- a/app/(anon)/interview/[id]/components/top/TopSection.tsx
+++ b/app/(anon)/interview/[id]/components/top/TopSection.tsx
@@ -14,7 +14,7 @@ export default function TopSection({ running, duration, onComplete }: TopSection
       <Timer running={running} duration={duration} onComplete={onComplete} />
       <div className="flex items-center gap-[8px] w-full justify-center ">
         <span
-          className={`flex w-[8px] h-[8px] rounded-[5px] ${running ? 'bg-[#3B82F6]' : 'bg-slate-300'}`}
+          className={`flex w-[8px] h-[8px] rounded-[5px] ${running ? 'bg-[#3B82F6]' : 'bg-slate-400'}`}
         ></span>
         <p
           className={`{whitespace-nowrap text-[13px] font-medium ${running ? 'text-[#3B82F6]' : 'text-slate-400'}`}

--- a/app/(anon)/interview/[id]/components/top/TopSection.tsx
+++ b/app/(anon)/interview/[id]/components/top/TopSection.tsx
@@ -10,7 +10,7 @@ interface TopSectionProps {
 
 export default function TopSection({ running, duration, onComplete }: TopSectionProps) {
   return (
-    <section className="flex px-[32px] flex-col justify-center items-center gap-[8px] border-b border-slate-200 bg-[#F8FAFC] py-[8px]">
+    <section className="flex px-[32px] flex-col justify-center items-center gap-[8px] border-b border-slate-200 bg-[#F8FAFC] py-[8px] cursor-default ">
       <Timer running={running} duration={duration} onComplete={onComplete} />
       <div className="flex items-center gap-[8px] w-full justify-center ">
         <span

--- a/app/(anon)/interview/[id]/components/user/MicVisualizer.tsx
+++ b/app/(anon)/interview/[id]/components/user/MicVisualizer.tsx
@@ -43,7 +43,7 @@ export default function MicVisualizer({
       const source = ctx.createMediaStreamSource(stream);
       /* 3. createAnalyser()로 분석 노드 붙이고 파라미터 설정 */
       const analyser = ctx.createAnalyser();
-      analyser.fftSize = 512; // 해상도 파라미터(크게하면 정밀하지만 반응이 느림)
+      analyser.fftSize = 128; // 해상도 파라미터(크게하면 정밀하지만 반응이 느림)
       analyser.smoothingTimeConstant = 0.8; //시간적으로 값이 덜 변동되게 하는 파라미터
       source.connect(analyser);
       analyserRef.current = analyser;

--- a/app/(anon)/interview/[id]/components/user/MicVisualizer.tsx
+++ b/app/(anon)/interview/[id]/components/user/MicVisualizer.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface MicVisualizerProps {
+  active?: boolean;
+  barsCount?: number;
+  className?: string;
+  colorClassName?: string; // Tailwind bg-* class, default blue-500
+  heightPx?: number;
+  baseScale?: number; // 0~1 사이, 기본 막대 높이(정지/저음 시)
+  colors?: string[]; // 막대별 색상 배열 (인라인 배경색 적용)
+}
+
+export default function MicVisualizer({
+  active = false,
+  barsCount = 20,
+  className = '',
+  colorClassName = 'bg-[#3B82F6]',
+  heightPx = 20,
+  baseScale = 0.35,
+  colors,
+}: MicVisualizerProps) {
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const freqDataRef = useRef<Uint8Array | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const visStreamRef = useRef<MediaStream | null>(null);
+  const barsRef = useRef<HTMLSpanElement[]>([]);
+
+  const clampedBase = Math.min(0.95, Math.max(0, baseScale));
+
+  const start = async () => {
+    try {
+      /* 1. 마이크 스트림 세팅 */
+      if (audioCtxRef.current) return;
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      visStreamRef.current = stream;
+      /* 2. AudioContext 생성 후 소스 노드 생성 */
+      const AC = (window as any).AudioContext || (window as any).webkitAudioContext;
+      const ctx: AudioContext = new AC();
+      audioCtxRef.current = ctx;
+      const source = ctx.createMediaStreamSource(stream);
+      /* 3. createAnalyser()로 분석 노드 붙이고 파라미터 설정 */
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 512; // 해상도 파라미터(크게하면 정밀하지만 반응이 느림)
+      analyser.smoothingTimeConstant = 0.8; //시간적으로 값이 덜 변동되게 하는 파라미터
+      source.connect(analyser);
+      analyserRef.current = analyser;
+      /* 4. 주파수 데이터를 담을 배열 생성 */
+      const data = new Uint8Array(analyser.frequencyBinCount);
+      freqDataRef.current = data;
+      /* 5. 매 프레임마다 막대 그리기 */
+      const draw = () => {
+        const a = analyserRef.current; //분석 노드
+        const d = freqDataRef.current; // 주파수 데이터
+        if (!a || !d) return;
+        a.getByteFrequencyData(d); // 주파수 데이터를 배열에 담기
+        const binSize = Math.max(1, Math.floor(d.length / barsCount)); // 한 막대가 담당할 원시 주파수 범위
+        //
+        for (let i = 0; i < barsCount; i++) {
+          let sum = 0;
+          const start = i * binSize; // 막대가 담당할 주파수 범위 시작점
+          const end = i === barsCount - 1 ? d.length : start + binSize; // 막대가 담당할 주파수 범위 끝점
+          for (let j = start; j < end; j++) sum += d[j];
+          const avg = sum / (end - start); // 평균 주파수 계산
+          const norm = avg / 255; // 0~255 사이의 값을 0~1로 정규화
+          const scale = Math.max(clampedBase, norm); // 너무 낮은 소리는 baseScale로 고정
+          const el = barsRef.current[i]; // 막대 요소에 연결
+          if (el) {
+            el.style.transform = `scaleY(${scale.toFixed(3)})`; // 막대 높이 조절
+          }
+        }
+        rafIdRef.current = requestAnimationFrame(draw);
+      };
+      rafIdRef.current = requestAnimationFrame(draw); // 첫 번째 프레임 그리기
+    } catch (_) {
+      console.error('비주얼라이저 오류 발생');
+    }
+  };
+
+  // 사용한 리소스들 해제
+  const stop = () => {
+    if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
+    rafIdRef.current = null;
+    try {
+      if (audioCtxRef.current) audioCtxRef.current.close();
+    } catch (_) {}
+    audioCtxRef.current = null;
+    analyserRef.current = null;
+    freqDataRef.current = null;
+    if (visStreamRef.current) {
+      visStreamRef.current.getTracks().forEach((t) => t.stop());
+      visStreamRef.current = null;
+    }
+    // 막대 높이 초기화
+    for (let i = 0; i < barsRef.current.length; i++) {
+      const el = barsRef.current[i];
+      if (el) {
+        el.style.transform = `scaleY(${clampedBase})`;
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (active) start();
+    else stop();
+    return () => stop();
+  }, [active]);
+
+  return (
+    <div className={`flex items-end gap-[3px] ${className}`} style={{ height: `${heightPx}px` }}>
+      {Array.from({ length: barsCount }).map((_, barIndex) => {
+        const bg =
+          Array.isArray(colors) && colors.length > 0 ? colors[barIndex % colors.length] : undefined;
+        return (
+          <span
+            key={barIndex}
+            ref={(el) => {
+              if (el) barsRef.current[barIndex] = el;
+            }}
+            className={`w-[3px] ${colorClassName}  will-change-transform rounded-[10px]`}
+            style={{
+              height: '100%',
+              transform: `scaleY(${clampedBase})`,
+              backgroundColor: bg,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -72,21 +72,21 @@ export default function UserAudio({ active = false, onFinish, onError }: UserAud
 
   return (
     <div
-      className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] p-4 flex gap-[8px] items-center cursor-default `}
+      className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border ${recordingStatus === 'recording' ? 'border-[#3B82F6] shadow-[0px_4px_16px_0px_rgba(59,130,246,0.25)]' : 'border-[#E2E8F0]'}  p-4 flex gap-[8px] items-center cursor-default `}
     >
       <Mic
         width={16}
         height={16}
-        className={`${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-slate-400'}`}
+        className={`${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-[#94A3B8]'}`}
       />
       <div
-        className={`flex items-center text-[14px] font-semibold ${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-slate-400 '}`}
+        className={`flex items-center text-[14px] font-semibold ${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-[#94A3B8]'}`}
       >
         {recordingStatus === 'recording' ? '음성 인식 중...' : '대기 중...'}
       </div>
       <div className="flex ml-auto">
         {recordingStatus === 'recording' && (
-          <MicVisualizer active={recordingStatus === 'recording'} barsCount={15} heightPx={30} />
+          <MicVisualizer active={recordingStatus === 'recording'} barsCount={14} heightPx={30} />
         )}
       </div>
     </div>

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -77,10 +77,10 @@ export default function UserAudio({
 
   return (
     <div
-      className={`absolute bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-white border border-[#E2E8F0] p-4 flex gap-[8px] items-center`}
+      className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] p-4 flex gap-[8px] items-center`}
     >
       <Mic width={16} height={16} />
-      <div className="flex items-center text-[#1E293B] text-[12px] font-medium">
+      <div className="flex items-center text-[#1E293B] text-[14px] font-medium">
         {text}
         {recordingStatus === 'recording' ? '' : '(대기)'}
       </div>

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -10,15 +10,9 @@ interface UserAudioProps {
   active?: boolean; // true면 자동 시작, false면 자동 정지
   onFinish?: (blob: Blob) => void; // 정지 시 생성된 오디오 Blob 전달
   onError?: (e: Error) => void;
-  text?: string;
 }
 
-export default function UserAudio({
-  active = false,
-  onFinish,
-  onError,
-  text = '음성 인식 중...',
-}: UserAudioProps) {
+export default function UserAudio({ active = false, onFinish, onError }: UserAudioProps) {
   const recorderRef = useRef<MicRecorder | null>(null);
   // onFinish의 중복 호출을 방지하기 위한 플래그
   const hasOnFinishFiredRef = useRef(false);
@@ -80,18 +74,25 @@ export default function UserAudio({
     <div
       className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] p-4 flex gap-[8px] items-center cursor-default `}
     >
-      <Mic width={16} height={16} />
-      <div className="flex items-center text-[#1E293B] text-[14px] font-medium">
-        {text}
-        {recordingStatus === 'recording' ? '' : '(대기)'}
+      <Mic
+        width={16}
+        height={16}
+        className={`${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-slate-400'}`}
+      />
+      <div
+        className={`flex items-center text-[14px] font-semibold ${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-slate-400 '}`}
+      >
+        {recordingStatus === 'recording' ? '음성 인식 중...' : '질문이 끝나면 녹음됩니다'}
       </div>
       <div className="flex ml-auto">
-        <MicVisualizer
-          active={recordingStatus === 'recording'}
-          barsCount={15}
-          heightPx={30}
-          colors={['#2563EB', '#3B82F6', '#1D4ED8']}
-        />
+        {recordingStatus === 'recording' && (
+          <MicVisualizer
+            active={recordingStatus === 'recording'}
+            barsCount={15}
+            heightPx={30}
+            colors={['#2563EB', '#3B82F6', '#1D4ED8']}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -4,6 +4,7 @@ import Mic from '@/public/assets/icons/mic.svg';
 import { useRef, useEffect, useState } from 'react';
 import MicRecorder from 'mic-recorder-to-mp3';
 import type { RecordingStatus } from '@/types/interview';
+import MicVisualizer from '@/app/(anon)/interview/[id]/components/user/MicVisualizer';
 
 interface UserAudioProps {
   active?: boolean; // true면 자동 시작, false면 자동 정지
@@ -83,6 +84,14 @@ export default function UserAudio({
       <div className="flex items-center text-[#1E293B] text-[14px] font-medium">
         {text}
         {recordingStatus === 'recording' ? '' : '(대기)'}
+      </div>
+      <div className="flex ml-auto">
+        <MicVisualizer
+          active={recordingStatus === 'recording'}
+          barsCount={15}
+          heightPx={30}
+          colors={['#2563EB', '#3B82F6', '#1D4ED8']}
+        />
       </div>
     </div>
   );

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -77,7 +77,7 @@ export default function UserAudio({
 
   return (
     <div
-      className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] p-4 flex gap-[8px] items-center`}
+      className={`absolute h-[64px] bottom-[52px] w-[calc(100%-104px)] rounded-[8px] bg-[#F8FAFC] border border-[#E2E8F0] p-4 flex gap-[8px] items-center cursor-default `}
     >
       <Mic width={16} height={16} />
       <div className="flex items-center text-[#1E293B] text-[14px] font-medium">

--- a/app/(anon)/interview/[id]/components/user/UserAudio.tsx
+++ b/app/(anon)/interview/[id]/components/user/UserAudio.tsx
@@ -82,16 +82,11 @@ export default function UserAudio({ active = false, onFinish, onError }: UserAud
       <div
         className={`flex items-center text-[14px] font-semibold ${recordingStatus === 'recording' ? 'text-[#3B82F6]' : 'text-slate-400 '}`}
       >
-        {recordingStatus === 'recording' ? '음성 인식 중...' : '질문이 끝나면 녹음됩니다'}
+        {recordingStatus === 'recording' ? '음성 인식 중...' : '대기 중...'}
       </div>
       <div className="flex ml-auto">
         {recordingStatus === 'recording' && (
-          <MicVisualizer
-            active={recordingStatus === 'recording'}
-            barsCount={15}
-            heightPx={30}
-            colors={['#2563EB', '#3B82F6', '#1D4ED8']}
-          />
+          <MicVisualizer active={recordingStatus === 'recording'} barsCount={15} heightPx={30} />
         )}
       </div>
     </div>

--- a/app/(anon)/page.tsx
+++ b/app/(anon)/page.tsx
@@ -2,10 +2,12 @@ import FastFiterviewStart from '@/app/(anon)/home/components/FastFiterviewStart'
 import FiterviewPrepare from '@/app/(anon)/home/components/FiterviewPrepare';
 import FiterviewStart from '@/app/(anon)/home/components/FiterviewStart';
 import FiterviewStrength from './home/components/FiterviewStrength';
+import MicVisualizer from './interview/[id]/components/user/MicVisualizer';
 
 export default function Page() {
   return (
     <div className="w-full h-full flex flex-col justify-center items-center">
+      <MicVisualizer active={true} />
       <FastFiterviewStart />
       <FiterviewPrepare />
       <FiterviewStrength />

--- a/app/(anon)/page.tsx
+++ b/app/(anon)/page.tsx
@@ -2,12 +2,10 @@ import FastFiterviewStart from '@/app/(anon)/home/components/FastFiterviewStart'
 import FiterviewPrepare from '@/app/(anon)/home/components/FiterviewPrepare';
 import FiterviewStart from '@/app/(anon)/home/components/FiterviewStart';
 import FiterviewStrength from './home/components/FiterviewStrength';
-import MicVisualizer from './interview/[id]/components/user/MicVisualizer';
 
 export default function Page() {
   return (
     <div className="w-full h-full flex flex-col justify-center items-center">
-      <MicVisualizer active={true} />
       <FastFiterviewStart />
       <FiterviewPrepare />
       <FiterviewStrength />


### PR DESCRIPTION
## 🔥 PR 제목  
> feat: 면접 환경 개선 및 질문 순서 로컬 스토리지에 저장


## ✨ 작업 내용
- 면접 페이지 UI 변경사항
  + 면접 질문 영역에 토글 버튼을 넣어 펼쳤다 접었다 할 수 있습니다.
  + 마이크 시각화 ui를 구현하여 녹음 진행상황을 확인할 수 있게 하였습니다.
  + TTS 상태면 질문 영역에 포커스가 되고, recording 상태면 녹음 영역에 포커스가 되게끔 하였습니다.
- <이슈> 면접질문의 순서를 로컬 스토리지에 저장하였는데 면접 페이지에 재진입 시 1로 값이 바뀌는 문제 
  + 해결 : 초기값을 로컬 스토리지에 있는 값으로 설정

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> /interview/{자신이 생성한 리포트id}


## 📸 스크린샷 / 시연 (선택)  
> 
**TTS 재생 중 화면**
https://github.com/user-attachments/assets/41597f1d-d14f-4d21-86d7-283d7ccb4fa6

**녹음 중 화면**
https://github.com/user-attachments/assets/0c587fcd-6409-4e82-abf9-c23914ed1392


## 🙏 리뷰어에게 한마디  
> 화이팅
