### PR TITLE
feat: 면접 진행 시 STT/피드백 처리를 백그라운드로 이동하여 사용자 경험 개선

### DIFF
--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -80,8 +80,11 @@ export default function InterviewClient() {
   const { audioRef, isPlaying } = useTtsAutoPlay(
     currentAudioSrc,
     () => {
-      setIsNextBtnDisabled(false);
       setPhase('recording');
+      // TTS 재생 완료 후 1초 동안 다음 버튼 비활성화
+      setTimeout(() => {
+        setIsNextBtnDisabled(false);
+      }, 1000); // 1초 대기
     },
     ttsEnabled
   );
@@ -176,7 +179,7 @@ export default function InterviewClient() {
       setCurrentOrder((o) => Math.min(10, o + 1));
     }
 
-    setIsNextBtnDisabled(false);
+    // setIsNextBtnDisabled(false);
     setIsUploading(false);
   };
 


### PR DESCRIPTION
## 🔥 PR 제목  
> feat: 면접 진행 시 STT/피드백 처리를 백그라운드로 이동하여 사용자 경험 개선


## ✨ 작업 내용

###  **STT와 피드백 처리 비동기화로 면접 지연 문제 해결**
- await에서 then/catch로 변경하여 백그라운드 실행
- 사용자가 다음 면접을 진행하는 동안 이전 질문에 대한 STT 동시 실행
- 사용자가 모든 면접을 완료하고 회고/면접팁 영상보기를 진행하는 동안, 백그라운드에서 피드백 생성

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> STT 처리 코드 변경
<img width="469" height="171" alt="스크린샷 2025-08-25 오전 1 42 55" src="https://github.com/user-attachments/assets/07b3bcb7-1796-4a31-b0b2-1c8f356cf21c" />


> 피드백 생성 코드 변경
<img width="439" height="150" alt="스크린샷 2025-08-25 오전 1 43 01" src="https://github.com/user-attachments/assets/7ab014a3-ce44-419a-83fa-f64b9911d59a" />


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
