### PR TITLE
로그인 후 메인홈으로 리라우팅 및 메인홈 하단 로그인 유도 컴포넌트 숨기기

### DIFF
--- a/app/(anon)/home/components/FiterviewStart.tsx
+++ b/app/(anon)/home/components/FiterviewStart.tsx
@@ -2,9 +2,11 @@
 import { motion } from 'framer-motion';
 import Start from '@/public/assets/icons/rocket.svg';
 import { useRouter } from 'next/navigation';
+import { useSessionUser } from '@/lib/auth/useSessionUser';
 
 export default function FiterviewStart() {
   const router = useRouter();
+  const { user } = useSessionUser();
 
   return (
     <div className="w-full px-28 py-20 bg-[#3B82F6] flex flex-col justify-start items-center gap-8">
@@ -49,7 +51,11 @@ export default function FiterviewStart() {
             y: 1,
             transition: { duration: 0.1, type: 'spring', stiffness: 100 },
           }}
-          onClick={() => router.push('/login')}
+          onClick={
+            user
+              ? () => window.scrollTo({ top: 0, behavior: 'smooth' })
+              : () => router.push('/login')
+          }
         >
           <motion.div
             whileHover={{
@@ -60,7 +66,7 @@ export default function FiterviewStart() {
             <Start width={20} height={20} stroke="#3B82F6" strokeWidth={1.67} />
           </motion.div>
           <p className="text-[#3B82F6] text-[16px] font-semibold leading-tight">
-            로그인하고 시작하기
+            {user ? '시작하기' : '로그인하고 시작하기'}
           </p>
         </motion.button>
       </motion.div>

--- a/app/(anon)/interview/[id]/components/InterviewClient.tsx
+++ b/app/(anon)/interview/[id]/components/InterviewClient.tsx
@@ -178,6 +178,16 @@ export default function InterviewClient() {
           console.error('피드백 생성 실패:', error);
         });
 
+      // 모범 답변 생성
+      axios
+        .post(`/api/reports/${reportId}/sample-answer`)
+        .then((sampleAnswerResult) => {
+          console.log('샘플 답변 생성 완료:', sampleAnswerResult.status);
+        })
+        .catch((error) => {
+          console.error('샘플 답변 생성 실패:', error);
+        });
+
       openModal('reflection');
     } else {
       // 즉시 다음 질문으로 이동하여 TTS 재생 시작

--- a/app/(anon)/login/page.tsx
+++ b/app/(anon)/login/page.tsx
@@ -61,7 +61,7 @@ export default function LoginPage() {
   // 로그인 성공 후 리다이렉트
   useEffect(() => {
     if (redirecting) {
-      router.push('/user');
+      router.push('/');
     }
   }, [redirecting, router]);
 

--- a/app/(anon)/login/page.tsx
+++ b/app/(anon)/login/page.tsx
@@ -221,7 +221,7 @@ export default function LoginPage() {
                       try {
                         // Google OAuth 로그인 시도 (계정 선택 강제)
                         await signIn('google', {
-                          callbackUrl: '/user',
+                          callbackUrl: '/',
                           prompt: 'select_account',
                         });
                       } catch (error) {

--- a/app/api/reports/[id]/sample-answer/route.ts
+++ b/app/api/reports/[id]/sample-answer/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       reportId: questions_report_idNumber,
       model: 'gpt-4o',
       instructions:
-        'Return a JSON array of best answers to each question. Format: ["Best answer 1", "Best answer 2", "Best answer 3"]. Each answer should be a string that provides a comprehensive and well-structured response to the corresponding question.',
+        'Return a JSON array of best answers to each question. Format: ["Best answer 1", "Best answer 2", "Best answer 3"]. Each answer should be a string that provides a comprehensive and well-structured response that is comprised of 3~5 sentences to the corresponding question.',
       input: '',
       maxOutputTokens: 1000,
     };


### PR DESCRIPTION
## 🔥 PR 제목  
> 로그인 후 메인홈으로 리라우팅 및 메인홈 하단 로그인 유도 컴포넌트 숨기기


## ✨ 작업 내용
- 로그인 후 메인홈으로 리라우팅 되도록 주소 설정 (자체 로그인, 구글 로그인 모두)
- 로그인 후 메인홈 하단의 FiterviewStart 컴포넌트에서 "로그인 후 시작하기" 버튼을 "시작하기"로 변경하고 이력서 업로드를 할 수 있는 페이지 상단으로 이동하도록 조건 조정
- 모법 답안 오작동 문제 해결

## 📸 스크린샷 / 시연 (선택) 

- 모범 답안 문제 해결
<img width="930" height="853" alt="스크린샷 2025-08-25 오후 4 14 55" src="https://github.com/user-attachments/assets/f310e3f3-796a-4ca7-8292-1e342e670fc1" />

- 로그인 전
<img width="1728" height="354" alt="스크린샷 2025-08-25 오후 2 41 32" src="https://github.com/user-attachments/assets/16f56c4e-9d17-4350-a0e9-db8cecdc6c0d" />

- 로그인 후
<img width="1728" height="347" alt="스크린샷 2025-08-25 오후 2 47 08" src="https://github.com/user-attachments/assets/56b9bb8c-eca6-4805-acda-d794b3e763e4" />


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
