### PR TITLE
fix: progress 모달  무한 루프 해결

### DIFF
--- a/app/components/modal/ReportProgressModal.tsx
+++ b/app/components/modal/ReportProgressModal.tsx
@@ -15,7 +15,8 @@ type Step = ProgressStep;
 
 export default function ReportProgressModal() {
   const { isOpen, currentStep, closeModal, replaceModal, openModal } = useModalStore();
-  const { jobId, reportId, setReportId, setJobId, onReportCompleted } = useReportStore();
+  const { jobId, reportId, setReportId, setJobId, clearJobId, onReportCompleted } =
+    useReportStore();
   const [sampleMessageIndex, setSampleMessageIndex] = useState(0);
 
   // 마운트 시 작업 ID 복구
@@ -50,6 +51,7 @@ export default function ReportProgressModal() {
       enabled: isOpen && currentStep === 'reportProgress' && (!!jobId || !!reportId),
       jobId,
       reportId,
+      onJobIdClear: () => clearJobId(),
     });
 
   useEffect(() => {
@@ -199,7 +201,7 @@ function getCopy(
       return {
         title: '질문 생성 중',
         description: samples[sampleMessageIndex ?? 0],
-        icon: '🤖',
+        icon: '💡',
       };
     }
     case 'creating_report':
@@ -217,7 +219,7 @@ function getCopy(
     case 'error':
       return {
         title: '오류 발생',
-        description: '생성 중 문제가 발생했어요.',
+        description: '작업을 진행할 수 없습니다. 다시 시도해주세요.',
         icon: '❌',
       };
     default:


### PR DESCRIPTION
## 🔥 PR 제목  
> fix: progress 모달  무한 루프 해결


##  문제상황:
질문생성요청 -> 진행 모달 -> 서버 중지 (yarn dev 끔) -> 켬 -> started 단계에서 더이상 단계가 나아가질 않음

더 자세하게!
- 서버 재시작 시 메모리 초기화 (JobId가 undifined가 아닌 started)
   (참고) started로 시작했던 이유는 새로고침시 질문생성을 이어서 요청받을 수 있게 하려는 목적이였음 
- 클라이언트는 localStorage의 jobId로 계속 API 호출 
   (참고) 파일 분석을 할 수 없는데 started 상태여서 무한루프 발생

## ✨ 작업 내용

-  작업 완료/에러 시 jobId 즉시 삭제
- started 상태에서 다음 단계로 진행할 수 없을 때 -> 에러 모달 표시
- 서버 재시작 후 started 상태에서 멈춰있을때(started상태 10번 이상 호출되면) -> 에러 모달 표시


## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> 

1. 파일 업로드 후 질문 생성 요청
2. 서버 강제 종료 (Ctrl+C 또는 프로세스 종료)
3. 서버 재시작 (npm run dev 또는 yarn dev)
4. 에러모달 등장

## 📸 스크린샷 / 시연 (선택)  
> UI 변경 사항이 있다면 스크린샷 또는 GIF를 첨부


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
