### PR TITLE
fix: 타이머 리렌더링 수정

### DIFF
--- a/app/(anon)/interview/[id]/components/top/Timer.tsx
+++ b/app/(anon)/interview/[id]/components/top/Timer.tsx
@@ -17,6 +17,11 @@ export default function Timer({ running, duration, onComplete }: TimerProps) {
   const rafIdRef = useRef<number | null>(null);
   // 완료 여부
   const completedRef = useRef(false);
+  // 최신 onComplete 콜백 저장
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
 
   // running 토글에 따라 타이머 시작/정지
   useEffect(() => {
@@ -42,7 +47,7 @@ export default function Timer({ running, duration, onComplete }: TimerProps) {
       if (left <= 0) {
         if (!completedRef.current) {
           completedRef.current = true;
-          onComplete?.();
+          onCompleteRef.current?.();
         }
         return; // rAF 루프 종료
       }

--- a/app/(anon)/interview/[id]/components/top/Timer.tsx
+++ b/app/(anon)/interview/[id]/components/top/Timer.tsx
@@ -57,7 +57,7 @@ export default function Timer({ running, duration, onComplete }: TimerProps) {
         rafIdRef.current = null;
       }
     };
-  }, [running, duration, onComplete]);
+  }, [running, duration]);
 
   // 진행바 % (실시간 계산)
   const percent = running ? Math.max(0, Math.min(remaining / duration, 1)) * 100 : 100;


### PR DESCRIPTION
## 🔥 PR 제목  
> fix: 타이머 리렌더링 수정


## ✨ 작업 내용
- [이슈] Timer가 카운트다운 중, 다음 버튼 활성화 시점에 남은 시간이 60으로 한 번 더 렌더링됨.
- [원인] onComplete 참조가 부모 리렌더 때 새로 생성되어 Timer의 effect 의존성에 의해 재시작.
- [해결] useEffect 의존성 배열에서 onComplete 제거


## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 📸 스크린샷 / 시연 (선택)  
> 
https://github.com/user-attachments/assets/b06f7f4f-449d-4772-a78a-ef1e8f53c94f


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
