### PR TITLE
fix: 배포 환경에서 마이페이지(/user) 307 리다이렉트 이슈 해결

### DIFF
--- a/app/api/auth/[...nextauth]/authOptions.ts
+++ b/app/api/auth/[...nextauth]/authOptions.ts
@@ -24,7 +24,10 @@ export const authOptions = {
   useSecureCookies: process.env.NODE_ENV === 'production',
   cookies: {
     sessionToken: {
-      name: `next-auth.session-token`,
+      name:
+        process.env.NODE_ENV === 'production'
+          ? `__Secure-next-auth.session-token`
+          : `next-auth.session-token`,
       options: {
         httpOnly: true, // XSS 공격 방지
         sameSite: 'lax', // CSRF 공격 방지


### PR DESCRIPTION
## 🔥 PR 제목  
> fix: 배포 환경에서 마이페이지(/user) 307 리다이렉트 이슈 해결


## ✨ 작업 내용
- [배경]
배포(HTTPS)에서 로그인 상태로 마이페이지 접근 시 /user가 307으로 /login?callbackUrl=/user로 리다이렉트됨.(개발 환경에선 잘 동작함)
- [원인]
- NextAuth 기본 동작은 환경에 따라 세션 쿠키 이름이 달라짐
개발(HTTP): next-auth.session-token
배포(HTTPS, useSecureCookies=true): __Secure-next-auth.session-token
- 우리는 sessionToken의 이름을 next-auth.session-token 로 명시해버려서 배포환경에서 자동으로 __Secure가 붙지 않음
- 결론적으로 배포 환경에서 __Secure-next-auth.session-token을 찾고 있는데 next-auth.session-token밖에 없어서 미들웨어가 "토큰이 없다"라고 판단한 것임
- [해결]
- 배포 환경이면 __Secure프리픽스 붙인 형태로 쿠키 이름 설정 추가


## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> 직접 테스트한 방법 또는 테스트 코드 내용 (있다면)


## 📸 스크린샷 / 시연 (선택)  
> UI 변경 사항이 있다면 스크린샷 또는 GIF를 첨부


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
