### PR TITLE
refactor: 사용자 답변 raw/clean 분리 및 STT prompt bias·후처리 도입

### DIFF
--- a/app/(anon)/reports/[id]/components/AudioReportViewer.tsx
+++ b/app/(anon)/reports/[id]/components/AudioReportViewer.tsx
@@ -49,11 +49,13 @@ export default function AudioReportViewer({ reportId }: AudioReportViewerProps) 
     setSelectedQuestion(question);
   };
 
-  // 사용자 답변 업데이트 핸들러
-  const handleUserAnswerUpdate = (questionOrder: number, newUserAnswer: string) => {
+  // 사용자 답변 업데이트 핸들러 (clean 텍스트만 갱신)
+  const handleUserAnswerUpdate = (questionOrder: number, newUserAnswerClean: string) => {
     if (report) {
       const updatedQuestions = report.questions.map((question: any) =>
-        question.order === questionOrder ? { ...question, userAnswer: newUserAnswer } : question
+        question.order === questionOrder
+          ? { ...question, userAnswerClean: newUserAnswerClean }
+          : question
       );
 
       setReport({
@@ -65,7 +67,7 @@ export default function AudioReportViewer({ reportId }: AudioReportViewerProps) 
       if (selectedQuestion && selectedQuestion.order === questionOrder) {
         setSelectedQuestion({
           ...selectedQuestion,
-          userAnswer: newUserAnswer,
+          userAnswerClean: newUserAnswerClean,
         });
       }
     }
@@ -90,7 +92,7 @@ export default function AudioReportViewer({ reportId }: AudioReportViewerProps) 
               key={question.id}
               questionNumber={question.order}
               questionText={question.question}
-              userAnswer={question.userAnswer}
+              userAnswerClean={question.userAnswerClean}
               sampleAnswer={question.sampleAnswer}
               isExpanded={false}
               showActions={false}

--- a/app/(anon)/reports/[id]/components/QuestionItem.tsx
+++ b/app/(anon)/reports/[id]/components/QuestionItem.tsx
@@ -9,7 +9,7 @@ import { ReportStatus } from '@/types/report';
 interface QuestionItemProps {
   questionNumber: number;
   questionText: string;
-  userAnswer?: string;
+  userAnswerClean?: string;
   sampleAnswer?: string;
   isExpanded?: boolean;
   showActions?: boolean;
@@ -17,13 +17,13 @@ interface QuestionItemProps {
   reportId?: number;
   reportStatus?: ReportStatus;
   onQuestionSelect?: () => void;
-  onUserAnswerUpdate?: (questionOrder: number, newUserAnswer: string) => void;
+  onUserAnswerUpdate?: (questionOrder: number, newUserAnswerClean: string) => void;
 }
 
 export default function QuestionItem({
   questionNumber,
   questionText,
-  userAnswer,
+  userAnswerClean,
   sampleAnswer,
   isExpanded = false,
   showActions = false,
@@ -36,7 +36,7 @@ export default function QuestionItem({
   const [expanded, setExpanded] = useState(isExpanded);
   const [showSampleAnswer, setShowSampleAnswer] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [editedAnswer, setEditedAnswer] = useState(userAnswer || '');
+  const [editedAnswer, setEditedAnswer] = useState(userAnswerClean || '');
 
   const toggleExpanded = () => {
     const newExpanded = !expanded;
@@ -57,7 +57,7 @@ export default function QuestionItem({
 
   const handleEdit = () => {
     setIsEditing(true);
-    setEditedAnswer(userAnswer || '');
+    setEditedAnswer(userAnswerClean || '');
     // 수정 모드 진입 시에는 AudioPlayer 업데이트하지 않음
   };
 
@@ -67,7 +67,7 @@ export default function QuestionItem({
     try {
       const response = await apiClient.put(
         `/api/reports/${reportId}/questions/${questionNumber}/user-answer`,
-        { userAnswer: editedAnswer }
+        { userAnswerClean: editedAnswer }
       );
 
       setIsEditing(false);
@@ -82,7 +82,7 @@ export default function QuestionItem({
 
   const handleCancel = () => {
     setIsEditing(false);
-    setEditedAnswer(userAnswer || '');
+    setEditedAnswer(userAnswerClean || '');
   };
 
   return (
@@ -156,7 +156,7 @@ export default function QuestionItem({
             </div>
           ) : (
             <div className="self-stretch justify-start text-gray-700 text-sm font-normal leading-snug">
-              {userAnswer || '사용자 답변이 존재하지 않습니다'}
+              {userAnswerClean || '사용자 답변이 존재하지 않습니다'}
             </div>
           )}
 

--- a/app/api/reports/[id]/questions/[order]/transcribe/route.ts
+++ b/app/api/reports/[id]/questions/[order]/transcribe/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { TranscribeAudioUseCase } from '@/backend/application/questions/usecases/TranscribeAudioUseCase';
 import { SaveUserAnswerUseCase } from '@/backend/application/questions/usecases/SaveUserAnswerUseCase';
 import { GetAudioByQuestionUseCase } from '@/backend/application/questions/usecases/GetAudioByQuestionUseCase';
+import { CleanTranscriptionService } from '@/backend/application/questions/services/CleanTranscriptionService';
 import { TranscribeSttAI } from '@/backend/infrastructure/AI/TranscribeSttAI';
 import { QuestionRepositoryImpl } from '@/backend/infrastructure/repositories/QuestionRepositoryImpl';
 import { FileProcessingService } from '@/backend/infrastructure/services/FileProcessingService';
@@ -34,8 +35,12 @@ export async function POST(
     const prisma = new PrismaClient();
     const sttRepository = new TranscribeSttAI();
     const questionRepository = new QuestionRepositoryImpl();
+    const cleanTranscriptionService = new CleanTranscriptionService();
 
-    const transcribeAudioUseCase = new TranscribeAudioUseCase(sttRepository);
+    const transcribeAudioUseCase = new TranscribeAudioUseCase(
+      sttRepository,
+      cleanTranscriptionService
+    );
     const saveUserAnswerUseCase = new SaveUserAnswerUseCase(prisma);
     const getAudioByQuestionUseCase = new GetAudioByQuestionUseCase(questionRepository);
 
@@ -58,8 +63,8 @@ export async function POST(
       );
     }
 
-    // STT 처리
-    const sttResult = await transcribeAudioUseCase.execute(
+    // STT 처리 (raw + clean)
+    const { raw, cleanText } = await transcribeAudioUseCase.execute(
       audioFileInfo.fileBuffer,
       audioFileInfo.fileName,
       'ko' // 기본값으로 한국어 설정
@@ -69,7 +74,8 @@ export async function POST(
     await saveUserAnswerUseCase.execute({
       reportId: reportIdNumber,
       order: orderNumber,
-      transcription: sttResult,
+      rawText: raw.text,
+      cleanText,
     });
 
     // 응답 생성
@@ -79,8 +85,9 @@ export async function POST(
       reportId: reportIdNumber,
       order: orderNumber,
       transcription: {
-        text: sttResult.text,
-        language: sttResult.language,
+        raw: raw.text,
+        clean: cleanText,
+        language: raw.language,
         model: 'gpt-4o-transcribe',
       },
     };

--- a/app/api/reports/[id]/questions/[order]/user-answer/route.ts
+++ b/app/api/reports/[id]/questions/[order]/user-answer/route.ts
@@ -30,9 +30,9 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const { userAnswer } = body as { userAnswer: string };
+    const { userAnswerClean } = body as { userAnswerClean: string };
 
-    if (!userAnswer || typeof userAnswer !== 'string') {
+    if (!userAnswerClean || typeof userAnswerClean !== 'string') {
       return NextResponse.json(
         { success: false, message: '사용자 답변이 필요합니다.' },
         { status: 400 }
@@ -62,7 +62,7 @@ export async function PUT(
     await updateUserAnswerUseCase.execute({
       reportId,
       order: questionOrder,
-      userAnswer,
+      userAnswerClean,
     });
 
     return NextResponse.json({

--- a/app/api/reports/[id]/route.ts
+++ b/app/api/reports/[id]/route.ts
@@ -148,7 +148,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       order: q.order,
       question: q.question,
       sampleAnswer: q.sampleAnswer,
-      userAnswer: q.userAnswer,
+      userAnswerRaw: q.userAnswerRaw,
+      userAnswerClean: q.userAnswerClean,
       recording: q.recording,
     }));
 

--- a/backend/application/questions/dtos/QuestionDto.ts
+++ b/backend/application/questions/dtos/QuestionDto.ts
@@ -3,6 +3,7 @@ export interface QuestionDto {
   order: number;
   question: string;
   sampleAnswer?: string;
-  userAnswer?: string;
+  userAnswerRaw?: string;
+  userAnswerClean?: string;
   recording?: string;
 }

--- a/backend/application/questions/services/CleanTranscriptionService.ts
+++ b/backend/application/questions/services/CleanTranscriptionService.ts
@@ -1,0 +1,37 @@
+import { FILLER_TOKENS } from '@/constants/stt';
+
+// STT raw 텍스트에 결정적이고 가역적인 최소 후처리만 적용해 clean 텍스트를 만든다.
+// LLM 호출이나 자유 재작성은 사용하지 않는다. raw는 항상 별도로 보존된다.
+export class CleanTranscriptionService {
+  private readonly fillerSet: Set<string>;
+  private readonly fillerRepeatPattern: RegExp;
+
+  constructor(fillerTokens: readonly string[] = FILLER_TOKENS) {
+    this.fillerSet = new Set(fillerTokens);
+    // 같은 filler 음절의 2회 이상 반복 ("어어", "음음음")도 함께 제거.
+    this.fillerRepeatPattern = new RegExp(`^(${fillerTokens.join('|')}){2,}$`);
+  }
+
+  clean(rawText: string): string {
+    if (!rawText) return '';
+    const withoutFillers = this.removeFillers(rawText);
+    return this.normalizeWhitespace(withoutFillers);
+  }
+
+  private removeFillers(text: string): string {
+    return text
+      .split(/\s+/)
+      .filter((token) => {
+        const core = token.replace(/[.,!?…]+$/u, '');
+        if (!core) return true;
+        if (this.fillerSet.has(core)) return false;
+        if (this.fillerRepeatPattern.test(core)) return false;
+        return true;
+      })
+      .join(' ');
+  }
+
+  private normalizeWhitespace(text: string): string {
+    return text.replace(/\s+/g, ' ').trim();
+  }
+}

--- a/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/SaveUserAnswerUseCase.ts
@@ -1,20 +1,19 @@
 import { PrismaClient } from '@prisma/client';
-import { STTResponse } from '@/backend/domain/dtos/STTResponse';
 
 export interface SaveUserAnswerRequest {
   reportId: number;
   order: number;
-  transcription: STTResponse;
+  rawText: string;
+  cleanText: string;
 }
 
-// STT 응답을 받아 DB에 저장
+// STT raw 텍스트와 후처리된 clean 텍스트를 함께 저장
 export class SaveUserAnswerUseCase {
   constructor(private prisma: PrismaClient) {}
 
   async execute(request: SaveUserAnswerRequest): Promise<void> {
-    const { reportId, order, transcription } = request;
+    const { reportId, order, rawText, cleanText } = request;
 
-    // 해당 report와 order에 맞는 question이 존재하는지 확인
     const question = await this.prisma.question.findFirst({
       where: {
         reportId,
@@ -26,11 +25,11 @@ export class SaveUserAnswerUseCase {
       throw new Error(`Question with reportId ${reportId} and order ${order} not found`);
     }
 
-    // 질문의 userAnswer 필드에 변환된 텍스트 저장
     await this.prisma.question.update({
       where: { id: question.id },
       data: {
-        userAnswer: transcription.text,
+        userAnswerRaw: rawText,
+        userAnswerClean: cleanText,
       },
     });
   }

--- a/backend/application/questions/usecases/TranscribeAudioUseCase.ts
+++ b/backend/application/questions/usecases/TranscribeAudioUseCase.ts
@@ -1,23 +1,37 @@
 import { SttAI } from '@/backend/domain/AI/SttAI';
 import { STTRequest } from '@/backend/domain/dtos/STTRequest';
 import { STTResponse } from '@/backend/domain/dtos/STTResponse';
+import { CleanTranscriptionService } from '@/backend/application/questions/services/CleanTranscriptionService';
+import { STT_PROMPT_BIAS } from '@/constants/stt';
+
+export interface TranscribeAudioResult {
+  raw: STTResponse;
+  cleanText: string;
+}
 
 export class TranscribeAudioUseCase {
-  constructor(private readonly sttRepository: SttAI) {}
+  constructor(
+    private readonly sttRepository: SttAI,
+    private readonly cleanService: CleanTranscriptionService
+  ) {}
 
-  async execute(audioFile: Buffer, fileName: string, language: string): Promise<STTResponse> {
+  async execute(
+    audioFile: Buffer,
+    fileName: string,
+    language: string
+  ): Promise<TranscribeAudioResult> {
     try {
-      // STTRequest 객체 생성
       const sttRequest: STTRequest = {
         audioFile,
         fileName,
         language,
+        prompt: STT_PROMPT_BIAS,
       };
 
-      // STT 처리
-      const transcription = await this.sttRepository.transcribeToText(sttRequest);
+      const raw = await this.sttRepository.transcribeToText(sttRequest);
+      const cleanText = this.cleanService.clean(raw.text);
 
-      return transcription;
+      return { raw, cleanText };
     } catch (error) {
       console.error('STT 처리 실패:', error);
       throw error;

--- a/backend/application/questions/usecases/UpdateUserAnswerUseCase.ts
+++ b/backend/application/questions/usecases/UpdateUserAnswerUseCase.ts
@@ -3,16 +3,17 @@ import { PrismaClient } from '@prisma/client';
 export interface UpdateUserAnswerRequest {
   reportId: number;
   order: number;
-  userAnswer: string;
+  userAnswerClean: string;
 }
 
+// 사용자가 직접 편집한 답변은 clean 필드에만 반영한다.
+// raw는 STT 원본 보존용이므로 사용자 편집으로 덮어쓰지 않는다.
 export class UpdateUserAnswerUseCase {
   constructor(private prisma: PrismaClient) {}
 
   async execute(request: UpdateUserAnswerRequest): Promise<void> {
-    const { reportId, order, userAnswer } = request;
+    const { reportId, order, userAnswerClean } = request;
 
-    // 해당 report와 order에 맞는 question이 존재하는지 확인
     const question = await this.prisma.question.findFirst({
       where: {
         reportId,
@@ -24,11 +25,10 @@ export class UpdateUserAnswerUseCase {
       throw new Error(`Question with reportId ${reportId} and order ${order} not found`);
     }
 
-    // 질문의 userAnswer 필드 업데이트
     await this.prisma.question.update({
       where: { id: question.id },
       data: {
-        userAnswer,
+        userAnswerClean,
       },
     });
   }

--- a/backend/domain/dtos/STTRequest.ts
+++ b/backend/domain/dtos/STTRequest.ts
@@ -3,4 +3,5 @@ export interface STTRequest {
   audioFile: Buffer; // 오디오 파일 데이터
   fileName: string; // 파일명
   language?: string; // 언어 (선택사항)
+  prompt?: string; // 도메인 용어 bias 등 모델 가이드 텍스트
 }

--- a/backend/domain/entities/Question.ts
+++ b/backend/domain/entities/Question.ts
@@ -4,7 +4,8 @@ export interface Question {
   question: string;
   reportId: number;
   sampleAnswer?: string;
-  userAnswer?: string;
+  userAnswerRaw?: string;
+  userAnswerClean?: string;
   recording?: string;
 }
 

--- a/backend/infrastructure/AI/TranscribeSttAI.ts
+++ b/backend/infrastructure/AI/TranscribeSttAI.ts
@@ -15,6 +15,7 @@ export class TranscribeSttAI implements SttAI {
         file: audioFile,
         model: 'gpt-4o-transcribe',
         ...(audioRequest.language && { language: audioRequest.language }),
+        ...(audioRequest.prompt && { prompt: audioRequest.prompt }),
         response_format: 'json',
       });
 

--- a/backend/infrastructure/repositories/FeedbackRepositoryImpl.ts
+++ b/backend/infrastructure/repositories/FeedbackRepositoryImpl.ts
@@ -1,7 +1,6 @@
 import prisma from '@/utils/prisma';
 import { FeedbackRepository } from '@/backend/domain/repositories/FeedbackRepository';
 import { Feedback } from '@/backend/domain/entities/Feedback';
-import { Question } from '@/backend/domain/entities/Question';
 import { ReportStatus } from '@prisma/client';
 
 export class FeedbackRepositoryImpl implements FeedbackRepository {
@@ -65,17 +64,18 @@ export class FeedbackRepositoryImpl implements FeedbackRepository {
 
   async getQuestionsAndAnswers(
     reportId: number
-  ): Promise<Pick<Question, 'question' | 'sampleAnswer' | 'userAnswer'>[]> {
+  ): Promise<{ question: string; sampleAnswer?: string | null; userAnswer?: string | null }[]> {
     const rows = await prisma.question.findMany({
       where: { reportId },
-      select: { question: true, sampleAnswer: true, userAnswer: true },
+      select: { question: true, sampleAnswer: true, userAnswerClean: true },
       take: 10,
     });
 
+    // LLM 평가는 후처리된 clean 텍스트를 사용한다.
     return rows.map((r) => ({
       question: r.question,
       sampleAnswer: r.sampleAnswer ?? undefined,
-      userAnswer: r.userAnswer ?? undefined,
+      userAnswer: r.userAnswerClean ?? undefined,
     }));
   }
 }

--- a/backend/infrastructure/repositories/QuestionRepositoryImpl.ts
+++ b/backend/infrastructure/repositories/QuestionRepositoryImpl.ts
@@ -46,7 +46,8 @@ export class QuestionRepositoryImpl implements QuestionRepository {
       order: (q as any).order ?? sortedQuestions[idx].order,
       question: q.question,
       sampleAnswer: q.sampleAnswer || undefined,
-      userAnswer: q.userAnswer || undefined,
+      userAnswerRaw: q.userAnswerRaw || undefined,
+      userAnswerClean: q.userAnswerClean || undefined,
       recording: q.recording || undefined,
       reportId: q.reportId,
     }));
@@ -99,7 +100,8 @@ export class QuestionRepositoryImpl implements QuestionRepository {
         question: q.question,
         reportId: q.reportId,
         sampleAnswer: q.sampleAnswer || undefined,
-        userAnswer: q.userAnswer || undefined,
+        userAnswerRaw: q.userAnswerRaw || undefined,
+        userAnswerClean: q.userAnswerClean || undefined,
         recording: q.recording || undefined,
       }));
     } catch (error) {

--- a/constants/stt.ts
+++ b/constants/stt.ts
@@ -1,0 +1,14 @@
+// STT 호출 시 모델에 전달되는 도메인 bias prompt.
+// 면접 도메인의 자주 등장하는 기술 용어와 표기 정책을 모델에게 힌트로 준다.
+// raw 텍스트의 인식 품질에 영향을 주므로 변경 시 benchmark 재측정 필요.
+export const STT_PROMPT_BIAS = [
+  '한국어 IT/기술 면접 답변 음성입니다.',
+  '자주 등장하는 용어: React, Next.js, TypeScript, JavaScript, Node.js, Python, Java, Spring, Spring Boot, Django, FastAPI, AWS, GCP, Azure, Docker, Kubernetes, MySQL, PostgreSQL, MongoDB, Redis, REST API, GraphQL, Git, GitHub, CI/CD, OAuth, JWT.',
+  '직무 용어: 프론트엔드, 백엔드, 풀스택, 데브옵스, 데이터베이스, 알고리즘, 자료구조, 객체지향, 함수형, 비동기, 동시성, 트랜잭션, 인덱스.',
+  '숫자는 가능한 한 아라비아 숫자로 표기합니다 (예: 3년, 10000명).',
+].join(' ');
+
+// 후처리에서 제거 대상이 되는 한국어 filler 토큰.
+// 단독 토큰 또는 같은 음절의 반복 형태만 제거한다 (예: "어", "어어", "음음음").
+// 일반 단어로 흔히 쓰이는 "그", "저", "뭐"는 오제거 위험이 커 포함하지 않는다.
+export const FILLER_TOKENS = ['어', '음', '에', '아'] as const;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "next start -p 3155 -H 0.0.0.0",
     "build": "prisma generate && NODE_OPTIONS='--max-old-space-size=4096' next build",
     "lint": "eslint .",
+    "benchmark:stt": "node scripts/benchmark-stt.mjs",
+    "test:stt": "node scripts/test-stt-pipeline.mjs",
     "prepare": "husky install",
     "format": "prettier --write ."
   },

--- a/prisma/migrations/20260511000000_split_user_answer_into_raw_and_clean/migration.sql
+++ b/prisma/migrations/20260511000000_split_user_answer_into_raw_and_clean/migration.sql
@@ -1,0 +1,11 @@
+-- Split user_answer into raw (STT 원본) + clean (후처리본)
+ALTER TABLE "questions" ADD COLUMN "user_answer_raw" TEXT;
+ALTER TABLE "questions" ADD COLUMN "user_answer_clean" TEXT;
+
+-- 기존 user_answer 값은 분리 이전 데이터라 raw/clean 구분이 없으므로 양쪽 모두에 복사한다.
+UPDATE "questions"
+SET "user_answer_raw" = "user_answer",
+    "user_answer_clean" = "user_answer"
+WHERE "user_answer" IS NOT NULL;
+
+ALTER TABLE "questions" DROP COLUMN "user_answer";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,14 +44,15 @@ model Feedback {
 }
 
 model Question {
-  id           Int     @id @default(autoincrement())
-  question     String
-  sampleAnswer String? @map("sample_answer")
-  userAnswer   String? @map("user_answer")
-  recording    String?
-  reportId     Int     @map("report_id")
-  order        Int?
-  report       Report  @relation("ReportQuestions", fields: [reportId], references: [id], onDelete: Cascade)
+  id              Int     @id @default(autoincrement())
+  question        String
+  sampleAnswer    String? @map("sample_answer")
+  userAnswerRaw   String? @map("user_answer_raw")
+  userAnswerClean String? @map("user_answer_clean")
+  recording       String?
+  reportId        Int     @map("report_id")
+  order           Int?
+  report          Report  @relation("ReportQuestions", fields: [reportId], references: [id], onDelete: Cascade)
 
   @@map("questions")
 }

--- a/scripts/benchmark-stt.mjs
+++ b/scripts/benchmark-stt.mjs
@@ -1,0 +1,161 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+if (!OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required in environment variables.');
+}
+
+const filePath = path.resolve(process.cwd(), 'public/assets/audios/2/recording_2_8.mp3');
+const model = 'gpt-4o-transcribe';
+const language = 'ko';
+const iterations = Number(process.env.STT_BENCH_ITERATIONS ?? '10');
+const endpoint = 'https://api.openai.com/v1/audio/transcriptions';
+const groundTruthText =
+  '어 음 그 10일만에 mvp를 만든거는 음 엄청 짧은 시간이라 사실 그 기획과 개발의 조율이 좀 힘들었어요 음 다들 바쁘고 급하다 보니까 우선순위를 빠르게 정하고 뭐 필요한 기능만 먼저 구현했어요 그런 조율이 기억에 남네요';
+
+if (!Number.isInteger(iterations) || iterations < 1) {
+  throw new Error('STT_BENCH_ITERATIONS must be a positive integer.');
+}
+
+const round = (value) => Math.round(value * 100) / 100;
+
+const percentile = (values, p) => {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+};
+
+const normalizeText = (text) =>
+  text
+    .toLowerCase()
+    .replace(/\s+/g, '')
+    .replace(/[^0-9a-z가-힣]/g, '');
+
+const levenshteinDistance = (source, target) => {
+  const rows = source.length + 1;
+  const cols = target.length + 1;
+  const matrix = Array.from({ length: rows }, () => Array(cols).fill(0));
+
+  for (let i = 0; i < rows; i += 1) matrix[i][0] = i;
+  for (let j = 0; j < cols; j += 1) matrix[0][j] = j;
+
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = source[i - 1] === target[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  return matrix[rows - 1][cols - 1];
+};
+
+async function transcribeOnce(audioBuffer) {
+  const audioBlob = new Blob([audioBuffer], { type: 'audio/mpeg' });
+  const formData = new FormData();
+  formData.append('file', audioBlob, 'recording_2_8.mp3');
+  formData.append('model', model);
+  formData.append('language', language);
+  formData.append('response_format', 'json');
+
+  const startedAt = performance.now();
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+    },
+    body: formData,
+  });
+  const endedAt = performance.now();
+  const latencyMs = endedAt - startedAt;
+
+  const payload = await response.json().catch(() => ({}));
+  const text = typeof payload?.text === 'string' ? payload.text.trim() : '';
+  const normalizedPrediction = normalizeText(text);
+  const normalizedGroundTruth = normalizeText(groundTruthText);
+  const editDistance = levenshteinDistance(normalizedPrediction, normalizedGroundTruth);
+  const cer =
+    normalizedGroundTruth.length === 0 ? 0 : editDistance / normalizedGroundTruth.length;
+  const accuracy = (1 - cer) * 100;
+  const success = response.ok && text.length > 0;
+  const errorMessage = success
+    ? null
+    : payload?.error?.message || payload?.message || `HTTP ${response.status}`;
+
+  return {
+    success,
+    latencyMs,
+    status: response.status,
+    sttText: text,
+    groundTruthText,
+    cer,
+    accuracy,
+    textLength: text.length,
+    errorMessage,
+  };
+}
+
+async function main() {
+  const audioBuffer = await readFile(filePath);
+  const results = [];
+  let failures = 0;
+
+  console.log('=== STT Benchmark Start ===');
+  console.log(`file: ${filePath}`);
+  console.log(`model: ${model}`);
+  console.log(`iterations: ${iterations}`);
+  console.log('');
+
+  for (let i = 0; i < iterations; i += 1) {
+    const attempt = i + 1;
+    const result = await transcribeOnce(audioBuffer);
+    results.push(result);
+    if (!result.success) failures += 1;
+
+    const status = result.success ? 'OK' : 'FAIL';
+    const baseLog = `[${attempt}/${iterations}] ${status} ${round(result.latencyMs)}ms (status=${result.status}, textLen=${result.textLength})`;
+    console.log(result.success ? baseLog : `${baseLog}, error=${result.errorMessage}`);
+    console.log(`  STT text     : ${result.sttText}`);
+    console.log(`  Ground truth : ${result.groundTruthText}`);
+    console.log(`  CER          : ${round(result.cer * 100)}%`);
+    console.log(`  Accuracy     : ${round(result.accuracy)}%`);
+  }
+
+  const latencies = results.map((result) => result.latencyMs);
+  const cerValues = results.map((result) => result.cer);
+  const accuracyValues = results.map((result) => result.accuracy);
+  const mean = latencies.reduce((acc, cur) => acc + cur, 0) / latencies.length;
+  const averageCer = cerValues.reduce((acc, cur) => acc + cur, 0) / cerValues.length;
+  const averageAccuracy =
+    accuracyValues.reduce((acc, cur) => acc + cur, 0) / accuracyValues.length;
+  const p50 = percentile(latencies, 50);
+  const p95 = percentile(latencies, 95);
+  const errorRate = (failures / iterations) * 100;
+
+  console.log('');
+  console.log('=== STT Benchmark Summary ===');
+  console.log(`total requests : ${iterations}`);
+  console.log(`success        : ${iterations - failures}`);
+  console.log(`failed         : ${failures}`);
+  console.log(`error rate     : ${round(errorRate)}%`);
+  console.log(`mean latency   : ${round(mean)}ms`);
+  console.log(`p50 latency    : ${round(p50)}ms`);
+  console.log(`p95 latency    : ${round(p95)}ms`);
+  console.log(`avg CER        : ${round(averageCer * 100)}%`);
+  console.log(`avg Accuracy   : ${round(averageAccuracy)}%`);
+}
+
+main().catch((error) => {
+  console.error('Benchmark failed:', error);
+  process.exitCode = 1;
+});

--- a/scripts/test-stt-pipeline.mjs
+++ b/scripts/test-stt-pipeline.mjs
@@ -1,0 +1,218 @@
+// STT 파이프라인 변경분(prompt bias + CleanTranscriptionService)을 DB 없이 검증하는 스크립트.
+// 동일 오디오에 대해 3가지 결과를 출력한다:
+//   1) baseline (prompt 없음, 변경 전 상태와 동일)
+//   2) with prompt bias (변경 후 raw 저장 대상)
+//   3) with prompt + clean (변경 후 clean 저장 대상)
+//
+// 사용: node scripts/test-stt-pipeline.mjs
+//   - STT_TEST_AUDIO=path/to/file.mp3  : 오디오 파일 경로 변경
+//   - STT_TEST_ITERATIONS=3             : 반복 횟수
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+if (!OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required in environment variables.');
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 아래 상수는 constants/stt.ts 와 동일하게 유지해야 한다.
+// constants/stt.ts 변경 시 이 파일도 함께 수정.
+const STT_PROMPT_BIAS = [
+  '한국어 IT/기술 면접 답변 음성입니다.',
+  '자주 등장하는 용어: React, Next.js, TypeScript, JavaScript, Node.js, Python, Java, Spring, Spring Boot, Django, FastAPI, AWS, GCP, Azure, Docker, Kubernetes, MySQL, PostgreSQL, MongoDB, Redis, REST API, GraphQL, Git, GitHub, CI/CD, OAuth, JWT.',
+  '직무 용어: 프론트엔드, 백엔드, 풀스택, 데브옵스, 데이터베이스, 알고리즘, 자료구조, 객체지향, 함수형, 비동기, 동시성, 트랜잭션, 인덱스.',
+  '숫자는 가능한 한 아라비아 숫자로 표기합니다 (예: 3년, 10000명).',
+].join(' ');
+
+const FILLER_TOKENS = ['어', '음', '에', '아'];
+const FILLER_SET = new Set(FILLER_TOKENS);
+const FILLER_REPEAT = new RegExp(`^(${FILLER_TOKENS.join('|')}){2,}$`);
+
+function cleanTranscription(raw) {
+  if (!raw) return '';
+  const withoutFillers = raw
+    .split(/\s+/)
+    .filter((t) => {
+      const core = t.replace(/[.,!?…]+$/u, '');
+      if (!core) return true;
+      if (FILLER_SET.has(core)) return false;
+      if (FILLER_REPEAT.test(core)) return false;
+      return true;
+    })
+    .join(' ');
+  return withoutFillers.replace(/\s+/g, ' ').trim();
+}
+// ─────────────────────────────────────────────────────────────────────
+
+const audioFilePath =
+  process.env.STT_TEST_AUDIO ||
+  path.resolve(process.cwd(), 'public/assets/audios/2/recording_2_8.mp3');
+const model = 'gpt-4o-transcribe';
+const language = 'ko';
+const iterations = Number(process.env.STT_TEST_ITERATIONS ?? '3');
+const endpoint = 'https://api.openai.com/v1/audio/transcriptions';
+
+// benchmark-stt.mjs 와 동일한 ground truth (filler 포함, raw 비교용)
+const groundTruthRaw =
+  '어 음 그 10일만에 mvp를 만든거는 음 엄청 짧은 시간이라 사실 그 기획과 개발의 조율이 좀 힘들었어요 음 다들 바쁘고 급하다 보니까 우선순위를 빠르게 정하고 뭐 필요한 기능만 먼저 구현했어요 그런 조율이 기억에 남네요';
+// clean 결과 비교용 (filler 제거 후)
+const groundTruthClean = cleanTranscription(groundTruthRaw);
+
+if (!Number.isInteger(iterations) || iterations < 1) {
+  throw new Error('STT_TEST_ITERATIONS must be a positive integer.');
+}
+
+const round = (v) => Math.round(v * 100) / 100;
+
+const normalizeText = (text) =>
+  text
+    .toLowerCase()
+    .replace(/\s+/g, '')
+    .replace(/[^0-9a-z가-힣]/g, '');
+
+const levenshteinDistance = (source, target) => {
+  const rows = source.length + 1;
+  const cols = target.length + 1;
+  const matrix = Array.from({ length: rows }, () => Array(cols).fill(0));
+  for (let i = 0; i < rows; i += 1) matrix[i][0] = i;
+  for (let j = 0; j < cols; j += 1) matrix[0][j] = j;
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = source[i - 1] === target[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return matrix[rows - 1][cols - 1];
+};
+
+const cerOf = (prediction, truth) => {
+  const np = normalizeText(prediction);
+  const nt = normalizeText(truth);
+  return nt.length === 0 ? 0 : levenshteinDistance(np, nt) / nt.length;
+};
+
+async function callOpenAI(audioBuffer, fileName, { withPrompt }) {
+  const audioBlob = new Blob([audioBuffer], { type: 'audio/mpeg' });
+  const formData = new FormData();
+  formData.append('file', audioBlob, fileName);
+  formData.append('model', model);
+  formData.append('language', language);
+  formData.append('response_format', 'json');
+  if (withPrompt) formData.append('prompt', STT_PROMPT_BIAS);
+
+  const startedAt = performance.now();
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${OPENAI_API_KEY}` },
+    body: formData,
+  });
+  const latencyMs = performance.now() - startedAt;
+  const payload = await response.json().catch(() => ({}));
+  const text = typeof payload?.text === 'string' ? payload.text.trim() : '';
+  const success = response.ok && text.length > 0;
+  return {
+    success,
+    latencyMs,
+    status: response.status,
+    text,
+    error: success ? null : payload?.error?.message || `HTTP ${response.status}`,
+  };
+}
+
+const avg = (arr, key) =>
+  arr.length ? arr.reduce((a, b) => a + b[key], 0) / arr.length : 0;
+
+async function main() {
+  const audioBuffer = await readFile(audioFilePath);
+  const fileName = path.basename(audioFilePath);
+
+  console.log('=== STT Pipeline Test (DB-less) ===');
+  console.log(`file        : ${audioFilePath}`);
+  console.log(`model       : ${model}`);
+  console.log(`iterations  : ${iterations}`);
+  console.log(`prompt bytes: ${STT_PROMPT_BIAS.length}`);
+  console.log('');
+  console.log(`ground truth (raw, filler 포함):`);
+  console.log(`  "${groundTruthRaw}"`);
+  console.log(`ground truth (clean, filler 제거 — 참고용):`);
+  console.log(`  "${groundTruthClean}"`);
+  console.log('');
+
+  const stats = { baseline: [], prompt: [], clean: [] };
+
+  for (let i = 0; i < iterations; i += 1) {
+    console.log(`--- iteration ${i + 1}/${iterations} ---`);
+
+    // 1) baseline (prompt 없음)
+    const baseline = await callOpenAI(audioBuffer, fileName, { withPrompt: false });
+    if (!baseline.success) {
+      console.log(`  [baseline]   FAIL status=${baseline.status} ${baseline.error}`);
+    } else {
+      const baselineCer = cerOf(baseline.text, groundTruthRaw);
+      console.log(
+        `  [baseline]   ${round(baseline.latencyMs)}ms  CER=${round(baselineCer * 100)}%`
+      );
+      console.log(`    text: "${baseline.text}"`);
+      stats.baseline.push({ latency: baseline.latencyMs, cer: baselineCer });
+    }
+
+    // 2) with prompt bias (변경 후 raw 저장 대상)
+    const withPrompt = await callOpenAI(audioBuffer, fileName, { withPrompt: true });
+    let promptText = '';
+    if (!withPrompt.success) {
+      console.log(`  [+prompt]    FAIL status=${withPrompt.status} ${withPrompt.error}`);
+    } else {
+      const promptCer = cerOf(withPrompt.text, groundTruthRaw);
+      promptText = withPrompt.text;
+      console.log(
+        `  [+prompt]    ${round(withPrompt.latencyMs)}ms  CER=${round(promptCer * 100)}%`
+      );
+      console.log(`    text: "${withPrompt.text}"`);
+      stats.prompt.push({ latency: withPrompt.latencyMs, cer: promptCer });
+    }
+
+    // 3) clean (with-prompt 결과에 후처리 적용 → 실제 user_answer_clean 후보)
+    if (promptText) {
+      const cleanText = cleanTranscription(promptText);
+      const cleanCer = cerOf(cleanText, groundTruthClean);
+      console.log(`  [+clean]     CER(vs cleanGT)=${round(cleanCer * 100)}%`);
+      console.log(`    text: "${cleanText}"`);
+      stats.clean.push({ cer: cleanCer });
+    }
+
+    console.log('');
+  }
+
+  console.log('=== Summary ===');
+  console.log(
+    `[baseline (no prompt)]   avg CER ${round(avg(stats.baseline, 'cer') * 100)}%   avg latency ${round(avg(stats.baseline, 'latency'))}ms   n=${stats.baseline.length}`
+  );
+  console.log(
+    `[+prompt bias]           avg CER ${round(avg(stats.prompt, 'cer') * 100)}%   avg latency ${round(avg(stats.prompt, 'latency'))}ms   n=${stats.prompt.length}`
+  );
+  console.log(
+    `[+clean post-process]    avg CER ${round(avg(stats.clean, 'cer') * 100)}% (vs cleanGT)   n=${stats.clean.length}`
+  );
+  console.log('');
+  console.log('주의:');
+  console.log('  - baseline / +prompt CER은 filler 포함 raw GT 기준');
+  console.log('  - +clean CER은 filler 제거된 cleanGT 기준이라 위 두 값과 직접 비교 X');
+  console.log('  - prompt bias 효과 = (baseline CER) - (+prompt CER)');
+  console.log('  - clean 후처리 효과 = +clean 결과 텍스트의 가독성/논리분석 적합성 (눈으로 확인)');
+}
+
+main().catch((error) => {
+  console.error('Test failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 🔥 PR 제목  
> 작업 유형(예: feat, fix, refactor 등) + 간결한 작업 요약 => feat: 작업내용


## ✨ 작업 내용
📝 Body                                                             
                  
  ## 요약

  사용자 답변을 STT 원본(raw)과 후처리본(clean) 두 컬럼으로 분리하고, 
  STT 호출에 도메인 prompt bias를 적용하는 파이프라인 개선.
                                                                      
  - **raw** — STT 원본 텍스트
  - **clean** — filler 제거 등 결정적 후처리 적용. LLM 평가·UI 표시·사용자 편집용                                                  
  - **prompt bias** — 면접 도메인 용어(React, Next.js 등)와 숫자 표기 정책을 STT 모델에 힌트로 전달  

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.


## 🚀 테스트 방법  
> 직접 테스트한 방법 또는 테스트 코드 내용 (있다면)


## 📸 스크린샷 / 시연 (선택)  
> UI 변경 사항이 있다면 스크린샷 또는 GIF를 첨부


## 🙏 리뷰어에게 한마디  
> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
